### PR TITLE
small ggdensitree modifications

### DIFF
--- a/R/ggdensitree.R
+++ b/R/ggdensitree.R
@@ -4,9 +4,8 @@
 ##' @param data a list of phylo objects or any object with an as.phylo and fortify method
 ##' @param mapping aesthetic mapping
 ##' @param layout one of 'slanted', 'rectangluar', 'fan', 'circular' or 'radial' (default: 'slanted')
-##' @param branch.length variable to be used to scale branch length. Setting to 'branch.length' will use the branch lengths of the tree objects. Default is 'none' to discard branch length and only plot cladogram (more reasonable for densitree).
 ##' @param tip.order the order of the tips by a character vector of taxa names; or an integer, N, to order the tips by the order of the tips in the Nth tree; or 'mds' to order the tips based on MDS of the distance between the tips (default: 'mds')
-##' @param dangle TRUE to align trees by their tips and FALSE to align treesby their root (default: TRUE)
+##' @param align.tips TRUE to align trees by their tips and FALSE to align trees by their root (default: TRUE)
 ##' @param jitter deviation to jitter tips
 ##' @param ... additional parameters passed to fortify, ggtree and geom_tree
 ##' @return tree layer
@@ -17,78 +16,88 @@
 ##' @examples
 ##' require(ape)
 ##' require(dplyr)
-##' library(ape)
 ##' 
-##' trees <- list(read.tree(text="((a,b),c);"), read.tree(text="((a,c),b);"));
+##' trees <- list(read.tree(text="((a:1,b:1):1.5,c:2.5);"), read.tree(text="((a:1,c:1):1,b:2);"));
 ##' ggdensitree(trees) + geom_tiplab()
 ##' 
 ##' trees.fort <- list(trees[[1]] %>% fortify %>% mutate(tree="a"), trees[[2]] %>% fortify %>% mutate(tree="b"));
 ##' ggdensitree(trees.fort, aes(colour=tree)) + geom_tiplab(colour='black')
-ggdensitree <- function(data=NULL, mapping=NULL, layout="slanted", branch.length = "none",
-                        tip.order='mds', dangle=TRUE, jitter=0, ...) {
-    ## factorize to simplify code
-    trees <- lapply(data, as.phylo)
-    trees.f <- lapply(data, fortify, layout=layout, branch.length = branch.length, ...)
-    n.tips <- sum(trees.f[[1]]$isTip)
-
-    ## determine tip order
-    if (length(tip.order) == 1) {
-        if (tip.order == 'mds') {
-            first.label <- trees.f[[1]] %>%
-                dplyr::filter(.data$isTip) %>%
-                dplyr::pull(.data$label)
-            
-            tip.order <- lapply(trees, function(x) {
-                match(x$tip.label, first.label)
-            })
-            
-            tip.2.tip <- lapply(trees, cophenetic.phylo.check.length)
-            tip.2.tip <- lapply(1:length(trees), function(i) {
-                tip.2.tip[[i]][tip.order[[i]], tip.order[[i]]]
-            })
-            
-            all.tab <- do.call(rbind, tip.2.tip)
-            rownames(all.tab) <- NULL
-            
-            distances <- stats::dist(t(all.tab))
-            
-            res <- stats::cmdscale(distances, k=1)
-			
-            tip.order <- first.label[order(res[,1])]
-        } else if (as.numeric(tip.order) && tip.order <= length(trees)) {
-            labels <- trees.f[[tip.order]] %>%
-                dplyr::filter(.data$isTip) %>%
-                dplyr::pull(.data$label)
-            
-            tip.order <- labels[as.integer(trees.f[[tip.order]]$y)]
-        }
-    }
+##' 
+##' set.seed(1)
+##' trees <- rmtree(5, 10)
+##' time.trees <- lapply(1:length(trees), function(i) {
+##'  	tree <- trees[[i]]
+##'  	tree$tip.label <- paste0("t", 1:10)
+##' 	dates <- estimate.dates(tree, 1:10, mu=1, nsteps=1)
+##' 	tree$edge.length <- dates[tree$edge[, 2]] - dates[tree$edge[, 1]]
+##' 	fortify(tree) %>% mutate(tree=factor(i, levels=as.character(1:10)))
+##' }) 
+##' ggdensitree(time.trees, aes(colour=tree), tip.order=paste0("t", 1:10)) + geom_tiplab(colour='black')
+ggdensitree <- function(data=NULL, mapping=NULL, layout="slanted", tip.order='mds',
+						align.tips=TRUE, jitter=0, ...) {
+	## factorize to simplify code
+	trees <- lapply(data, as.phylo)
+	trees.f <- lapply(data, fortify, layout=layout, ...)
+	n.tips <- sum(trees.f[[1]]$isTip)
 	
-    ## reorder tips (and shift x id dangling)
-    max.x <- vapply(trees.f, function(x) max(x$x, na.rm = TRUE), numeric(1))
-    farthest <- max(max.x)
-    trees.f <- lapply(1:length(trees), function(i) {
-        trees.f[[i]]$y <- getYcoord(trees[[i]], tip.order = tip.order)
-        if (dangle) {
-            trees.f[[i]]$x <- trees.f[[i]]$x + (farthest - max.x[i])
-        }
-        if (i > 1 && jitter > 0) {
-            trees.f[[i]]$y[1:n.tips] %<>% add(stats::rnorm(n.tips, mean=0, sd=jitter))
-        }
-        trees.f[[i]]
-    })
-    
-    ## plot all trees together
-    p <- ggtree(tr=trees.f[[1]], mapping=mapping, layout=layout, ...)
-    for (x in trees.f[-1])
-        p <- p + geom_tree(mapping=mapping, data=x, layout=layout, ...)
-    p
+	## determine tip order
+	if (length(tip.order) == 1) {
+		if (tip.order == 'mds') {
+			first.label <- trees.f[[1]] %>%
+				dplyr::filter(.data$isTip) %>%
+				dplyr::pull(.data$label)
+			
+			tip.order <- lapply(trees, function(x) {
+				match(x$tip.label, first.label)
+			})
+			
+			tip.2.tip <- lapply(trees, cophenetic.phylo.check.length)
+			tip.2.tip <- lapply(1:length(trees), function(i) {
+				tip.2.tip[[i]][tip.order[[i]], tip.order[[i]]]
+			})
+			
+			all.tab <- do.call(rbind, tip.2.tip)
+			rownames(all.tab) <- NULL
+			
+			distances <- stats::dist(t(all.tab))
+			
+			res <- stats::cmdscale(distances, k=1)
+			
+			tip.order <- first.label[order(res[,1])]
+		} else if (as.numeric(tip.order) && tip.order <= length(trees)) {
+			labels <- trees.f[[tip.order]] %>%
+				dplyr::filter(.data$isTip) %>%
+				dplyr::pull(.data$label)
+			
+			tip.order <- labels[as.integer(trees.f[[tip.order]]$y)]
+		}
+	}
+	
+	## reorder tips (and shift x id align tips)
+	max.x <- vapply(trees.f, function(x) max(x$x, na.rm = TRUE), numeric(1))
+	farthest <- max(max.x)
+	trees.f <- lapply(1:length(trees), function(i) {
+		trees.f[[i]]$y <- getYcoord(trees[[i]], tip.order = tip.order)
+		if (align.tips) {
+			trees.f[[i]]$x <- trees.f[[i]]$x + (farthest - max.x[i])
+		}
+		if (i > 1 && jitter > 0) {
+			trees.f[[i]]$y[1:n.tips] %<>% add(stats::rnorm(n.tips, mean=0, sd=jitter))
+		}
+		trees.f[[i]]
+	})
+	
+	## plot all trees together
+	p <- ggtree(tr=trees.f[[1]], mapping=mapping, layout=layout, ...)
+	for (x in trees.f[-1])
+		p <- p + geom_tree(mapping=mapping, data=x, layout=layout, ...)
+	p
 }
 
 ## wrapper for cohpenetic to ensure that branch lengths exist
 cophenetic.phylo.check.length <- function(tree) {
-    if (is.null(tree$edge.length))
-        tree$edge.length <- rep(1, nrow(tree$edge))
-    
-    stats::cophenetic(tree)
+	if (is.null(tree$edge.length))
+		tree$edge.length <- rep(1, nrow(tree$edge))
+	
+	stats::cophenetic(tree)
 }

--- a/man/ggdensitree.Rd
+++ b/man/ggdensitree.Rd
@@ -5,8 +5,7 @@
 \title{ggdensitree}
 \usage{
 ggdensitree(data = NULL, mapping = NULL, layout = "slanted",
-  branch.length = "none", tip.order = "mds", dangle = TRUE,
-  jitter = 0, ...)
+  tip.order = "mds", align.tips = TRUE, jitter = 0, ...)
 }
 \arguments{
 \item{data}{a list of phylo objects or any object with an as.phylo and fortify method}
@@ -15,11 +14,9 @@ ggdensitree(data = NULL, mapping = NULL, layout = "slanted",
 
 \item{layout}{one of 'slanted', 'rectangluar', 'fan', 'circular' or 'radial' (default: 'slanted')}
 
-\item{branch.length}{variable to be used to scale branch length. Setting to 'branch.length' will use the branch lengths of the tree objects. Default is 'none' to discard branch length and only plot cladogram (more reasonable for densitree).}
-
 \item{tip.order}{the order of the tips by a character vector of taxa names; or an integer, N, to order the tips by the order of the tips in the Nth tree; or 'mds' to order the tips based on MDS of the distance between the tips (default: 'mds')}
 
-\item{dangle}{TRUE to align trees by their tips and FALSE to align treesby their root (default: TRUE)}
+\item{align.tips}{TRUE to align trees by their tips and FALSE to align trees by their root (default: TRUE)}
 
 \item{jitter}{deviation to jitter tips}
 
@@ -34,13 +31,23 @@ drawing phylogenetic trees from list of phylo objects
 \examples{
 require(ape)
 require(dplyr)
-library(ape)
 
-trees <- list(read.tree(text="((a,b),c);"), read.tree(text="((a,c),b);"));
+trees <- list(read.tree(text="((a:1,b:1):1.5,c:2.5);"), read.tree(text="((a:1,c:1):1,b:2);"));
 ggdensitree(trees) + geom_tiplab()
 
 trees.fort <- list(trees[[1]] \%>\% fortify \%>\% mutate(tree="a"), trees[[2]] \%>\% fortify \%>\% mutate(tree="b"));
 ggdensitree(trees.fort, aes(colour=tree)) + geom_tiplab(colour='black')
+
+set.seed(1)
+trees <- rmtree(5, 10)
+time.trees <- lapply(1:length(trees), function(i) {
+ 	tree <- trees[[i]]
+ 	tree$tip.label <- paste0("t", 1:10)
+	dates <- estimate.dates(tree, 1:10, mu=1, nsteps=1)
+	tree$edge.length <- dates[tree$edge[, 2]] - dates[tree$edge[, 1]]
+	fortify(tree) \%>\% mutate(tree=factor(i, levels=as.character(1:10)))
+}) 
+ggdensitree(time.trees, aes(colour=tree), tip.order=paste0("t", 1:10)) + geom_tiplab(colour='black')
 }
 \author{
 Yu Guangchuang, Bradley R. Jones


### PR DESCRIPTION
Hi Yu,

I am happy with the changes you made to my PR #253, except that I don't think that `branch.length="none"` because the intended use of ggdensitree is to align tips vertically and horizontally from time scaled trees. The reason that `ape::rmtree` produces weird figures in `ggdensitree` is that the tips in those random trees will not have the same root-tip-distances in each tree. `ape::rcoal` works better to make random trees for `ggdensitree`.

I changed the example to include branch lengths and added a second example that is hetrochronous.

I also changed the `dangle` parameter to `align.tips` because I think that name is clearer.