### PR TITLE
Unrooted layout fix

### DIFF
--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -4,7 +4,7 @@
 ##' @title geom_tree
 ##' @param mapping aesthetic mapping
 ##' @param data data
-##' @param layout one of 'rectangular', 'slanted', 'fan', 'circular', 'radial', 'equal_angle' or 'daylight'
+##' @param layout one of 'rectangular', 'slanted', 'fan', 'circular', 'radial', 'equal_angle', 'daylight' or 'ape'
 ##' @param multiPhylo logical
 ##' @param ... additional parameter
 ##' @return tree layer
@@ -70,7 +70,7 @@ stat_tree <- function(mapping=NULL, data=NULL, geom="segment", position="identit
                    check.aes = FALSE
                    )
              )
-    } else if (layout %in% c("slanted", "radial", "equal_angle", "daylight")) {
+    } else if (layout %in% c("slanted", "radial", "equal_angle", "daylight", "ape")) {
         layer(stat=StatTree,
               data=data,
               mapping=mapping,

--- a/R/ggtree.R
+++ b/R/ggtree.R
@@ -101,6 +101,8 @@ ggtree <- function(tr,
         p <- p + layout_circular()
     } else if (layout == "fan") {
         p <- p + layout_fan(open.angle)
+    } else if (layout %in% c("daylight", "equal_angle")) {
+        p <- p + ggplot2::coord_fixed()
     } else {
         p <- p +
             scale_y_continuous(expand = expand_scale(0, 0.6))

--- a/R/ggtree.R
+++ b/R/ggtree.R
@@ -55,7 +55,8 @@ ggtree <- function(tr,
 
     # Check if layout string is valid.
     layout %<>% match.arg(c("rectangular", "slanted", "fan", "circular",
-                            "radial", "unrooted", "equal_angle", "daylight"))
+                            "radial", "unrooted", "equal_angle", "daylight",
+                            "ape"))
 
     if (layout == "unrooted") {
         layout <- "daylight"
@@ -101,7 +102,7 @@ ggtree <- function(tr,
         p <- p + layout_circular()
     } else if (layout == "fan") {
         p <- p + layout_fan(open.angle)
-    } else if (layout %in% c("daylight", "equal_angle")) {
+    } else if (layout %in% c("daylight", "equal_angle", "ape")) {
         p <- p + ggplot2::coord_fixed()
     } else {
         p <- p +

--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -29,7 +29,7 @@ fortify.phylo <- function(model, data,
         }
     }
 
-    if (layout %in% c("equal_angle", "daylight")) {
+    if (layout %in% c("equal_angle", "daylight", "ape")) {
         res <- layout.unrooted(model, layout.method = layout, branch.length = branch.length, ...)
     } else {
         if (is.null(x$edge.length) || branch.length == "none") {

--- a/man/geom_tree.Rd
+++ b/man/geom_tree.Rd
@@ -17,7 +17,7 @@ geom_tree(
 
 \item{data}{data}
 
-\item{layout}{one of 'rectangular', 'slanted', 'fan', 'circular', 'radial', 'equal_angle' or 'daylight'}
+\item{layout}{one of 'rectangular', 'slanted', 'fan', 'circular', 'radial', 'equal_angle', 'daylight' or 'ape'}
 
 \item{multiPhylo}{logical}
 

--- a/man/ggtree.Rd
+++ b/man/ggtree.Rd
@@ -28,7 +28,7 @@ ggtree(
 
 \item{mapping}{aesthetic mapping}
 
-\item{layout}{one of 'rectangular', 'slanted', 'fan', 'circular', 'radial', 'equal_angle' or 'daylight'}
+\item{layout}{one of 'rectangular', 'slanted', 'fan', 'circular', 'radial', 'equal_angle', 'daylight' or 'ape'}
 
 \item{open.angle}{open angle, only for 'fan' layout}
 


### PR DESCRIPTION
Hi Guangchuang,

I was trying to use the unrooted layouts in ggtree and I found that my trees always came out looking squished. Looking in the code I noticed that in `ggtree` function a yscale is added to the plot expanding the yscale by 0.6, which is more than my tree's length. Hence, I changed the `ggtree` function to use "coord_fixed` instead to plot with an 1:1 aspect ratio, which I think make more sense as a default.

I also wrote in ape's unrooted layout. Though I didn't make it work with variable `branch.length`s yet.

I put these changes in separate commits in case you don't want the ape layout.