### PR TITLE
if yscale is set do not scale y

### DIFF
--- a/R/ggtree.R
+++ b/R/ggtree.R
@@ -104,7 +104,7 @@ ggtree <- function(tr,
         p <- p + layout_fan(open.angle)
     } else if (layout %in% c("daylight", "equal_angle", "ape")) {
         p <- p + ggplot2::coord_fixed()
-    } else {
+    } else if (yscale == "none") {
         p <- p +
             scale_y_continuous(expand = expand_scale(0, 0.6))
     }


### PR DESCRIPTION
Hi Guangchuang,

I have another PR related to y-scaling. If the `yscale` parameter is set in the `ggtree` method, then I don't think that the the y should be scaled with `+scale_y_continuous(expand=c(0, 0.6)` because if the variable scaled by is much less than 0.6 then there will be a lot of padding. You may want to do the same with `yscale_mapping` parameter.  See the example below:

```R
library(ggtree)
library(ape)
library(phylobase)

set.seed(0)
tree <- phylo4d(rtree(5), all.data = data.frame(var = rnorm(9, sd = 0.0001)))

# compare
ggtree(tree, yscale = "var")

# to
ggtree(tree, yscale = "var") + ggplot2::scale_y_continuous(expand = c(0, 0.0001))
```