### PR TITLE
update geom_hilight to support geom_hilight(data=tbl_tree, node=selected_node)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 + `geom_tiplab()` and `geom_nodelab()` support `geom = "shadowtext"` 
 + `tree_filter()` which return a function to subset ggtree plot data in geom layers (2020-08-29, Sat)
 + update man files of `geom_rootedge` and `geom_point2`
++ update `geom_hilight` to support `geom_hilight(data = tbl_tree, node = selected_node)`. (2020-09-03, Thu)
 
 # ggtree 2.3.4
 

--- a/R/geom_hilight.R
+++ b/R/geom_hilight.R
@@ -187,7 +187,7 @@ get_clade_position <- function(treeview, node) {
   get_clade_position_(treeview$data, node)
 }
 
-get_clade_position_ <- function(data, node) {
+get_clade_position_ <- function(data, node, reverse=FALSE) {
     sp <- tryCatch(offspring.tbl_tree(data, node)$node, error=function(e) NULL)
     i <- match(node, data$node)
     if (is.null(sp)) {
@@ -202,12 +202,19 @@ get_clade_position_ <- function(data, node) {
     y <- sp.df$y
 
     if ("branch.length" %in% colnames(data)) {
-        xmin <- min(x, na.rm=TRUE) - data[["branch.length"]][i]/2
+        if (reverse){
+            xmin <- min(x, na.rm=TRUE)
+            xmax <- max(x, na.rm=TRUE) + data[["branch.length"]][i]/2
+        }else{
+            xmin <- min(x, na.rm=TRUE) - data[["branch.length"]][i]/2
+            xmax <- max(x, na.rm=TRUE)
+        }
     } else {
         xmin <- min(sp.df$branch, na.rm=TRUE)
+        xmax <- max(x, na.rm=TRUE)
     }
     data.frame(xmin=xmin,
-               xmax=max(x, na.rm=TRUE),
+               xmax=xmax,
                ymin=min(y, na.rm=TRUE) - 0.5,
                ymax=max(y, na.rm=TRUE) + 0.5)
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -174,11 +174,24 @@ build_cladeids_df <- function(trdf, nodeids){
 }
 
 build_cladeids_df2 <- function(trdf, nodeids){
-    dat <- lapply(nodeids, function(i)get_clade_position_(data=trdf, node=i))
+    flagreverse <- check_reverse(data=trdf)
+    dat <- lapply(nodeids, function(i)get_clade_position_(data=trdf, node=i, reverse=flagreverse))
     dat <- do.call("rbind", dat)
     dat$clade_root_node <- nodeids
     return(dat)
 }
+
+check_reverse <- function(data){
+    tiptab <- data[data$isTip,]
+    nodetab <- data[match(tiptab$parent, data$node),]
+    if (all(tiptab$x < nodetab$x)){
+        return(TRUE)
+    }else{
+        return(FALSE)
+    }
+}
+
+
 
 choose_hilight_layer <- function(object, type){
     if (type=="encircle"){


### PR DESCRIPTION
update `geom_hilight`, when the data of `geom_hilight(data=tbl_tree, node=selected_node)` is from data of `fortify` of `ggtree`, it will hight light the node in the data. The examples

```
library(dplyr)
library(ggtree)
library(ggplot2)

set.seed(1024)

x <- rtree(30)
y <- rtree(30)
p1 <- ggtree(x)
p2 <- ggtree(y)
                                                                                                                                                                                                                   d1 <- p1$data
d2 <- p2$data

## reverse x-axis and
## set offset to make the tree in the right hand side of the first tree
d2$x <- max(d2$x) - d2$x + max(d1$x) + 1

pp<- p1 +
     geom_tiplab() +
     geom_hilight(             #  Because it don't provided data, but have subset in mapping,  
         mapping=aes(       #   so it will extract from the data of p1 to high light.
                     subset=node%in%c(38, 48, 58, 36),
                     node=node,
                     fill=as.factor(node)
                     )
     )+
     ggnewscale::new_scale_fill() +
     geom_tree(data=d2) +
     geom_hilight(
         data = d2,            # Because it provided data, and the data is from the p2$data, 
         mapping = aes(   # so it will extract from the data to high light.
                       subset=node%in%c(38, 48, 58),
                       node=node,
                       fill=as.factor(node))
                      ) +
     geom_tiplab(data = d2, hjust=1)

dd <- bind_rows(d1, d2) %>%
  filter(!is.na(label))

pp <- pp + geom_line(aes(x, y, group=label), data=dd, color='grey')
```
![test](https://user-images.githubusercontent.com/17870644/92063759-8c3bda00-edce-11ea-9a36-fd5078c97ef4.png)
