### PR TITLE
fix geom_nodelab to support circular layout

### DIFF
--- a/R/geom_nodelab.R
+++ b/R/geom_nodelab.R
@@ -12,12 +12,12 @@
 ##' @export
 ##' @author Guangchuang Yu
 geom_nodelab <- function(mapping = NULL, nudge_x = 0, nudge_y = 0, geom = "text", hjust = 0.5, ...) {
-    self_mapping <- aes_(subset = ~!isTip)
-    if (is.null(mapping)) {
-        mapping <- self_mapping
-    } else {
-        mapping <- modifyList(self_mapping, mapping)
-    }
+    #self_mapping <- aes_(subset = ~!isTip)
+    #if (is.null(mapping)) {
+    #    mapping <- self_mapping
+    #} else {
+    #    mapping <- modifyList(self_mapping, mapping)
+    #}
 
-    geom_tiplab(mapping, offset = nudge_x, nudge_y = nudge_y, geom = geom, hjust = hjust, nodelab=TRUE, ...)
+    geom_tiplab(mapping, offset = nudge_x, nudge_y = nudge_y, geom = geom, hjust = hjust, ...)
 }

--- a/R/geom_nodelab.R
+++ b/R/geom_nodelab.R
@@ -19,5 +19,5 @@ geom_nodelab <- function(mapping = NULL, nudge_x = 0, nudge_y = 0, geom = "text"
         mapping <- modifyList(self_mapping, mapping)
     }
 
-    geom_tiplab(mapping, offset = nudge_x, nudge_y = nudge_y, geom = geom, hjust = hjust, ...)
+    geom_tiplab(mapping, offset = nudge_x, nudge_y = nudge_y, geom = geom, hjust = hjust, nodelab=TRUE, ...)
 }

--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -22,6 +22,10 @@
 ##' ggtree(tr) + geom_tiplab()
 geom_tiplab <- function(mapping=NULL, hjust = 0,  align = FALSE, linetype = "dotted",
                         linesize=0.5, geom="text",  offset=0, as_ylab = FALSE, ...) {
+    #####in order to check whether it is geom_nodelab
+    .call <- match.call(call = sys.call(sys.parent(1)))
+    nodelab <- ifelse(as.list(.call)[[1]]=="geom_nodelab", TRUE, FALSE)
+    #####
     structure(list(mapping = mapping,
                    hjust = hjust,
                    align = align,
@@ -30,6 +34,7 @@ geom_tiplab <- function(mapping=NULL, hjust = 0,  align = FALSE, linetype = "dot
                    geom = geom,
                    offset = offset,
                    as_ylab = as_ylab,
+                   nodelab = nodelab,
                    ...),
               class = "tiplab")
 }
@@ -121,11 +126,12 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
 ##' @seealso [geom_tiplab]
 geom_tiplab2 <- function(mapping=NULL, hjust=0, ...) {
     params <- list(...)
-    nodelab <- ifelse("nodelab" %in% names(params), TRUE, FALSE)
-    if (nodelab){
+    if (params[["nodelab"]]){
+        # for geom_nodelab
         subset1 <- "(!isTip & (angle < 90 | angle > 270))"
         subset2 <- "(!isTip & (angle >= 90 & angle <= 270))"
     }else{
+        # for geom_tiplab
         subset1 <- "(isTip & (angle < 90 | angle > 270))"
         subset2 <- "(isTip & (angle >= 90 & angle <=270))"
     }
@@ -134,13 +140,8 @@ geom_tiplab2 <- function(mapping=NULL, hjust=0, ...) {
 
     if (!is.null(mapping)) {
         if (!is.null(mapping$subset)) {
-            if (nodelab){
-                newsubset1 <- paste0(as.expression(get_aes_var(mapping, "subset")), '& (angle < 90 | angle > 270)')
-                newsubset2 <- paste0(as.expression(get_aes_var(mapping, "subset")), '& (angle >= 90 & angle <= 270)')
-            }else{
-                newsubset1 <- paste0(as.expression(get_aes_var(mapping, "subset")), '& (isTip & (angle < 90 | angle > 270))')
-                newsubset2 <- paste0(as.expression(get_aes_var(mapping, "subset")), '& (isTip & (angle >= 90 & angle <= 270))')
-            }
+            newsubset1 <- paste0(as.expression(get_aes_var(mapping, "subset")), '&', subset1)
+            newsubset2 <- paste0(as.expression(get_aes_var(mapping, "subset")), '&', subset2)
             m1 <- aes_string(angle = "angle", node = "node", subset = newsubset1)
             m2 <- aes_string(angle = "angle+180", node = "node", subset = newsubset2)
         }

--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -6,9 +6,22 @@
 ##' @param data data
 ##' @param layout one of 'rectangular', 'dendrogram', 'slanted', 'ellipse', 'roundrect',
 ##' 'fan', 'circular', 'inward_circular', 'radial', 'equal_angle', 'daylight' or 'ape'
-##' @param multiPhylo logical
+##' @param multiPhylo logical, whether input data contains multiple phylo class.
 ##' @param ... additional parameter
+##' 
+##' some dot arguments:
+##' \itemize{
+##'    \item \code{continuous} logical, whether the aesthethic of `size` or `color` is continuous, default is FALSE.
+##'    \item \code{nsplit} integer, the number of branch blocks divided when `continuous` is TRUE, default is 200.
+##' }
 ##' @return tree layer
+##' @section Aesthetics:
+#' \code{geom_tree()} understands the following aesthethics:
+##'     \itemize{
+##'        \item \code{colour} logical, control the color of line, default is black.
+##'        \item \code{linetype} control the type of line, default is 1 (solid).
+##'        \item \code{size} numeric, control the width of line, default is 0.5.
+##'     }
 ##' @importFrom ggplot2 geom_segment
 ##' @importFrom ggplot2 aes
 ##' @export

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -205,6 +205,7 @@ ggplot_add.tiplab <- function(object, plot, object_name) {
         object$linesize <- NULL
         object$geom <- NULL
         object$offset <- NULL
+        object$nodelab <- NULL
         object$as_ylab <- NULL
             
         res <- ggplot_add.tiplab_ylab(object, plot, object_name)

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -217,6 +217,7 @@ ggplot_add.tiplab <- function(object, plot, object_name) {
         layout == "inward_circular") {
         ly <- do.call(geom_tiplab_circular, object)
     } else {
+        object$nodelab <- NULL
         ly <- do.call(geom_tiplab_rectangular, object)
     }
     ggplot_add(ly, plot, object_name)

--- a/man/geom_tree.Rd
+++ b/man/geom_tree.Rd
@@ -20,9 +20,15 @@ geom_tree(
 \item{layout}{one of 'rectangular', 'dendrogram', 'slanted', 'ellipse', 'roundrect',
 'fan', 'circular', 'inward_circular', 'radial', 'equal_angle', 'daylight' or 'ape'}
 
-\item{multiPhylo}{logical}
+\item{multiPhylo}{logical, whether input data contains multiple phylo class.}
 
-\item{...}{additional parameter}
+\item{...}{additional parameter
+
+some dot arguments:
+\itemize{
+\item \code{continuous} logical, whether the aesthethic of \code{size} or \code{color} is continuous, default is FALSE.
+\item \code{nsplit} integer, the number of branch blocks divided when \code{continuous} is TRUE, default is 200.
+}}
 }
 \value{
 tree layer
@@ -30,6 +36,16 @@ tree layer
 \description{
 add tree layer
 }
+\section{Aesthetics}{
+
+\code{geom_tree()} understands the following aesthethics:
+\itemize{
+\item \code{colour} logical, control the color of line, default is black.
+\item \code{linetype} control the type of line, default is 1 (solid).
+\item \code{size} numeric, control the width of line, default is 0.5.
+}
+}
+
 \author{
 Yu Guangchuang
 }

--- a/man/ggtree.Rd
+++ b/man/ggtree.Rd
@@ -54,7 +54,13 @@ right-hand side? See \code{\link[ape:ladderize]{ape::ladderize()}} for more info
 
 \item{xlim}{x limits, only works for 'inward_circular' layout}
 
-\item{...}{additional parameter}
+\item{...}{additional parameter
+
+some dot arguments:
+\itemize{
+\item \code{continuous} logical, whether the aesthethic of \code{size} or \code{color} is continuous, default is FALSE.
+\item \code{nsplit} integer, the number of branch blocks divided when \code{continuous} is TRUE, default is 200.
+}}
 }
 \value{
 tree


### PR DESCRIPTION
The original `geom_nodelab` dont't supports circular layout. https://github.com/YuLab-SMU/ggtree/issues/352
This is because the `subset` of `mapping` in `geom_nodelab` was set to `!isTip & (isTip & angle ...)` via `geom_tiplab2` when layout is circular. So `geom_tiplab2` has been modified to support it.

the example
```
library(ggtree)
library(tibble)

nwk <- system.file("extdata", "sample.nwk", package="treeio")
tree <- read.tree(nwk)
td <- as_tibble(tree)
td$label <- LETTERS[seq.int(1L, nrow(td))]

p <- ggtree(tidytree::as.treedata(td),
            layout="circular"
            ) +
     geom_nodelab(aes(subset=label%in%c("T","R", "X")),nudge_x=1.5) +
     geom_tiplab(align=TRUE)
p
```
![test](https://user-images.githubusercontent.com/17870644/100183128-29fbfc80-2f19-11eb-9406-1938ff1f7b9d.png)
