### PR TITLE
fix geom_tiplab2

### DIFF
--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -126,7 +126,7 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
 ##' @seealso [geom_tiplab]
 geom_tiplab2 <- function(mapping=NULL, hjust=0, ...) {
     params <- list(...)
-    if (params[["nodelab"]]){
+    if ("nodelab" %in% names(params) && params[["nodelab"]]){
         # for geom_nodelab
         subset1 <- "(!isTip & (angle < 90 | angle > 270))"
         subset2 <- "(!isTip & (angle >= 90 & angle <= 270))"


### PR DESCRIPTION
因为nodelab参数在geom_tiplab2默认是没有的，所以如果没有判断直接调用geom_tiplab2会报错，之前没有注意到geom_tiplab2