### PR TITLE
fix geom_rootedge to support reversed x

### DIFF
--- a/R/ggplot-add-utilities.R
+++ b/R/ggplot-add-utilities.R
@@ -17,9 +17,13 @@ build_cladeids_df2 <- function(trdf, nodeids){
 }
 
 check_reverse <- function(data){
+    # extract tip point data
     tiptab <- data[data$isTip,]
+    # extract the corresponding parent point data, it might generate NA.
     nodetab <- data[match(tiptab$parent, data$node),]
-    if (all(tiptab$x < nodetab$x)){
+    # remove the NA, and if all x values of tip are smaller than 
+    # corresponding parent x values, the x of tree is reversed.
+    if (all(tiptab$x <= nodetab$x, na.rm=TRUE)){
         return(TRUE)
     }else{
         return(FALSE)


### PR DESCRIPTION
geom_rootedge support reversed x. #357  

```
library(ggplot2)
library(ggtree)

set.seed(1024)
test_tree <- rtree(6)
test_tree$root.edge <- 0.2
p <- ggtree(
         test_tree,
         layout="roundrect",
         size = 1
     ) +
     geom_tiplab(
         offset = -0.05
     ) +
     geom_rootedge(
         size = 1
     ) +
     scale_x_reverse() +
     theme_tree2()
p
```
![test](https://user-images.githubusercontent.com/17870644/102460598-312eaa00-4082-11eb-84b3-4515d093dfab.png)
