### PR TITLE
add offset.label and label to geom_treescale

### DIFF
--- a/R/geom_treescale.R
+++ b/R/geom_treescale.R
@@ -27,8 +27,8 @@ geom_treescale <- function(x=NULL, y=NULL, width=NULL, offset=NULL,
 
     default_aes <- aes_(x=~x, y=~y)
     mapping <- default_aes
-    if (is.null(label)){
-        list(
+
+    ly <- list(
             stat_treeScaleLine(xx=x, yy=y, width=width, color=color, offset=offset, size=linesize,
                                offset.label=offset.label, labelname=label,
                                mapping=mapping, data=data,
@@ -41,26 +41,14 @@ geom_treescale <- function(x=NULL, y=NULL, width=NULL, offset=NULL,
                                position=position, show.legend = show.legend,
                                inherit.aes = inherit.aes, na.rm=na.rm)
          )   
-    }else{
-        list(
-            stat_treeScaleLine(xx=x, yy=y, width=width, color=color, offset=offset, size=linesize,
-                               offset.label=offset.label, labelname=label,
-                               mapping=mapping, data=data,
-                               position=position, show.legend = show.legend,
-                               inherit.aes = inherit.aes, na.rm=na.rm),
-            stat_treeScaleText(xx=x, yy=y, width=width, color=color, offset=offset,
-                               offset.label=offset.label, labelname=label,
-                               size=fontsize, family = family,
-                               mapping=mapping, data=data,
-                               position=position, show.legend = show.legend,
-                               inherit.aes = inherit.aes, na.rm=na.rm),
-            stat_treeScaleLabel(xx=x, yy=y, width=width, color=color, offset=offset,
+    if (!is.null(label)){
+        ly[[3]] <- stat_treeScaleLabel(xx=x, yy=y, width=width, color=color, offset=offset,
                                 offset.label=offset.label, labelname=label,
                                 size=fontsize, family=family, mapping=mapping, data=data,
                                 position=position, show.legend=show.legend,
                                 inherit.aes = inherit.aes, na.rm=na.rm)
-        )
     }
+    return(ly)
 }
 
 
@@ -213,24 +201,21 @@ get_treescale_position <- function(data, xx, yy, width, offset=NULL, offset.labe
     } else {
         d <- width
     }
-    
-    if (!is.null(offset.label)){
-        offset.label <- offset.label
-    }
 
     if (is.null(offset)) {
         offset <- 0.4
-        if (is.null(offset.label)){
-            offset.label <- -0.4
-        }
     }
-     
-    if (is.null(label) || is.null(offset.label)){
-        list(LinePosition=data.frame(x=x, xend=x+d, y=y, yend=y),
-             TextPosition=data.frame(x=x+d/2, y=y+offset, label=d))
-    }else{
-        list(LinePosition=data.frame(x=x, xend=x+d, y=y, yend=y),
-             TextPosition=data.frame(x=x+d/2, y=y+offset, label=d),
-             LabelPosition=data.frame(x=x+d/2, y=y+offset.label, label=label))
+    if (is.null(offset.label)){
+        offset.label <- -0.4
+    } 
+  
+    res <-  list(LinePosition = data.frame(x=x, xend=x+d, y=y, yend=y),
+                 TextPosition = data.frame(x=x+d/2, y=y+offset, label=d)
+                )
+  
+    if (!is.null(label)){
+        res[["LabelPosition"]] <- data.frame(x=x+d/2, y=y+offset.label, label=label)
     }
+    
+    return(res)
 }

--- a/R/geom_treescale.R
+++ b/R/geom_treescale.R
@@ -6,6 +6,8 @@
 ##' @param y y position
 ##' @param width width of scale
 ##' @param offset offset of text to line
+##' @param label the title of tree scale, default is NULL.
+##' @param offset.label offset of scale title to line.
 ##' @param color color
 ##' @param linesize size of line
 ##' @param fontsize size of text
@@ -13,7 +15,8 @@
 ##' @return ggplot layers
 ##' @export
 ##' @author Guangchuang Yu
-geom_treescale <- function(x=NULL, y=NULL, width=NULL, offset=NULL, color="black",
+geom_treescale <- function(x=NULL, y=NULL, width=NULL, offset=NULL, 
+                           offset.label=NULL, label=NULL, color="black",
                            linesize=0.5, fontsize=3.88, family="sans") {
 
     data=NULL
@@ -24,25 +27,47 @@ geom_treescale <- function(x=NULL, y=NULL, width=NULL, offset=NULL, color="black
 
     default_aes <- aes_(x=~x, y=~y)
     mapping <- default_aes
-
-    list(
-        stat_treeScaleLine(xx=x, yy=y, width=width, color=color, offset=offset, size=linesize,
-                           mapping=mapping, data=data,
-                           position=position, show.legend = show.legend,
-                           inherit.aes = inherit.aes, na.rm=na.rm),
-        stat_treeScaleText(xx=x, yy=y, width=width, color=color, offset=offset,
-                           size=fontsize, family = family,
-                           mapping=mapping, data=data,
-                           position=position, show.legend = show.legend,
-                           inherit.aes = inherit.aes, na.rm=na.rm)
-    )
+    if (is.null(label)){
+        list(
+            stat_treeScaleLine(xx=x, yy=y, width=width, color=color, offset=offset, size=linesize,
+                               offset.label=offset.label, labelname=label,
+                               mapping=mapping, data=data,
+                               position=position, show.legend = show.legend,
+                               inherit.aes = inherit.aes, na.rm=na.rm),
+            stat_treeScaleText(xx=x, yy=y, width=width, color=color, offset=offset,
+                               offset.label=offset.label, labelname=label,
+                               size=fontsize, family = family,
+                               mapping=mapping, data=data,
+                               position=position, show.legend = show.legend,
+                               inherit.aes = inherit.aes, na.rm=na.rm)
+         )   
+    }else{
+        list(
+            stat_treeScaleLine(xx=x, yy=y, width=width, color=color, offset=offset, size=linesize,
+                               offset.label=offset.label, labelname=label,
+                               mapping=mapping, data=data,
+                               position=position, show.legend = show.legend,
+                               inherit.aes = inherit.aes, na.rm=na.rm),
+            stat_treeScaleText(xx=x, yy=y, width=width, color=color, offset=offset,
+                               offset.label=offset.label, labelname=label,
+                               size=fontsize, family = family,
+                               mapping=mapping, data=data,
+                               position=position, show.legend = show.legend,
+                               inherit.aes = inherit.aes, na.rm=na.rm),
+            stat_treeScaleLabel(xx=x, yy=y, width=width, color=color, offset=offset,
+                                offset.label=offset.label, labelname=label,
+                                size=fontsize, family=family, mapping=mapping, data=data,
+                                position=position, show.legend=show.legend,
+                                inherit.aes = inherit.aes, na.rm=na.rm)
+        )
+    }
 }
 
 
 
 stat_treeScaleLine <- function(mapping=NULL, data=NULL,
                            geom="segment", position="identity",
-                           xx, yy, width, offset, color, ...,
+                           xx, yy, width, offset, color, offset.label, labelname, ...,
                            show.legend=NA, inherit.aes=FALSE, na.rm=FALSE){
 
     default_aes <- aes_(x=~x, y=~y, xend=~x, yend=~y)
@@ -63,6 +88,8 @@ stat_treeScaleLine <- function(mapping=NULL, data=NULL,
                     yy=yy,
                     width=width,
                     offset=offset,
+                    offset.label=offset.label,
+                    labelname=labelname,
                     color=color,
                     na.rm=na.rm,
                     ...)
@@ -71,7 +98,7 @@ stat_treeScaleLine <- function(mapping=NULL, data=NULL,
 
 stat_treeScaleText <- function(mapping=NULL, data=NULL,
                                geom="text", position="identity",
-                               xx, yy, width, offset, color, ...,
+                               xx, yy, width, offset, color, offset.label, labelname, ...,
                                show.legend=NA, inherit.aes=TRUE, na.rm=FALSE) {
 
     default_aes <- aes_(x=~x, y=~y, label=~x)
@@ -92,6 +119,8 @@ stat_treeScaleText <- function(mapping=NULL, data=NULL,
                       yy=yy,
                       width=width,
                       offset=offset,
+                      offset.label=offset.label,
+                      labelname=labelname,
                       color=color,
                       na.rm=na.rm,
                       vjust = 0,
@@ -99,25 +128,68 @@ stat_treeScaleText <- function(mapping=NULL, data=NULL,
     )
 }
 
+stat_treeScaleLabel <- function(mapping=NULL, data=NULL, 
+                                geom="text", position="identity", 
+                                xx, yy, width, offset, color, offset.label, labelname, ...,
+                                show.legend=NA, inherit.aes=TRUE, na.rm=FALSE){
+    default_aes <- aes_(x=~x, y=~y, label=~x)
+    if (is.null(mapping)) {
+        mapping <- default_aes
+    }else{
+        mapping <- modifyList(mapping, default_aes)
+    }
+    layer(
+        stat = StatTreeScaleLabel,
+        data = data,
+        mapping = mapping,     
+        geom = GeomText,
+        position = position,
+        show.legend = show.legend,
+        inherit.aes = inherit.aes,
+        params = list(xx = xx,
+                     yy = yy,
+                     width = width,
+                     offset = offset,
+                     color = color,
+                     offset.label = offset.label,
+                     labelname=labelname,
+                     na.rm = na.rm,
+                     vjust = 0,
+                     ...                    
+                      )
+           
+    )
+
+}
 
 StatTreeScaleLine <- ggproto("StatTreeScaleLine", Stat,
-                             compute_group = function(self, data, scales, params, xx, yy, width, offset) {
-                                 get_treescale_position(data, xx, yy, width, offset)[[1]]
+                             compute_group = function(self, data, scales, params, xx, yy, width, offset, offset.label, labelname) {
+                                 get_treescale_position(data=data, xx=xx, yy=yy, width=width, 
+                                                        offset=offset, offset.label=offset.label, label=labelname)[[1]]
                              },
                              required_aes = c("x", "y", "xend", "yend")
                              )
 
 
 StatTreeScaleText <- ggproto("StatTreeScaleText", Stat,
-                             compute_group = function(self, data, scales, params, xx, yy, width, offset) {
-                                 get_treescale_position(data, xx, yy, width, offset)[[2]]
+                             compute_group = function(self, data, scales, params, xx, yy, width, offset, offset.label, labelname) {
+                                 get_treescale_position(data=data, xx=xx, yy=yy, width=width, 
+                                                        offset=offset, offset.label=offset.label, label=labelname)[[2]]
                              },
                              required_aes = c("x", "y", "label")
                              )
 
 
+StatTreeScaleLabel <- ggproto("StatTreeScaleLabel", Stat, 
+                              compute_panel = function(self, data, scales, params, xx, yy, width, offset, offset.label, labelname){
+                                 get_treescale_position(data=data, xx=xx, yy=yy, width=width, 
+                                                        offset=offset, offset.label=offset.label, label=labelname)[[3]]
+                              },
+                              required_aes = c("x", "y", "label")
+                              )
 
-get_treescale_position <- function(data, xx, yy, width, offset=NULL) {
+
+get_treescale_position <- function(data, xx, yy, width, offset=NULL, offset.label=NULL, label=NULL) {
     x <- xx
     y <- yy
     dx <- data$x %>% range %>% diff
@@ -141,11 +213,24 @@ get_treescale_position <- function(data, xx, yy, width, offset=NULL) {
     } else {
         d <- width
     }
+    
+    if (!is.null(offset.label)){
+        offset.label <- offset.label
+    }
 
     if (is.null(offset)) {
         offset <- 0.4
+        if (is.null(offset.label)){
+            offset.label <- -0.4
+        }
     }
-
-    list(LinePosition=data.frame(x=x, xend=x+d, y=y, yend=y),
-         TextPosition=data.frame(x=x+d/2, y=y+offset, label=d))
+     
+    if (is.null(label) || is.null(offset.label)){
+        list(LinePosition=data.frame(x=x, xend=x+d, y=y, yend=y),
+             TextPosition=data.frame(x=x+d/2, y=y+offset, label=d))
+    }else{
+        list(LinePosition=data.frame(x=x, xend=x+d, y=y, yend=y),
+             TextPosition=data.frame(x=x+d/2, y=y+offset, label=d),
+             LabelPosition=data.frame(x=x+d/2, y=y+offset.label, label=label))
+    }
 }

--- a/man/geom_treescale.Rd
+++ b/man/geom_treescale.Rd
@@ -9,6 +9,8 @@ geom_treescale(
   y = NULL,
   width = NULL,
   offset = NULL,
+  offset.label = NULL,
+  label = NULL,
   color = "black",
   linesize = 0.5,
   fontsize = 3.88,
@@ -23,6 +25,10 @@ geom_treescale(
 \item{width}{width of scale}
 
 \item{offset}{offset of text to line}
+
+\item{offset.label}{offset of scale title to line.}
+
+\item{label}{the title of tree scale, default is NULL.}
 
 \item{color}{color}
 


### PR DESCRIPTION
add offset.label and label to geom_treescale, these parameters will control the title of tree scale. offset.label represents the distance between line and title of tree scale. #359 

for example

```
library(ggtree)
library(ggplot2)
library(patchwork)

set.seed(2020)
x = rtree(5)

p1 <- ggtree(x) + geom_treescale(x=2, y=1, offset=.1, offset.label=-0.2, label="substitution rate")

p2 <- ggtree(x) + geom_treescale(x=2, y=1, offset=-.2, offset.label=0.1,label="substitution rate")

p <- p1 + p2
p
```
![treescale_fig](https://user-images.githubusercontent.com/17870644/102876181-d16c4080-447f-11eb-9073-7064d0e58a83.png)

I had tried convert `x` and `y` to `npc` unit, and the `width` should be keeped `native` unit. But it can not create data.frame to plot tree scale. I think if we want to convert `x` and `y` to `npc` unit, we might need to create `treescaleGrob`. 