### PR TITLE
change default vjust of label to 1 in geom_treescale

### DIFF
--- a/R/geom_treescale.R
+++ b/R/geom_treescale.R
@@ -154,7 +154,7 @@ stat_treeScaleLabel <- function(mapping=NULL, data=NULL,
                      offset.label = offset.label,
                      labelname=labelname,
                      na.rm = na.rm,
-                     vjust = 0,
+                     vjust = 1,
                      ...                    
                       )
            


### PR DESCRIPTION
The vjust of label in `geom_treescale` has been set to 1 #359 