### PR TITLE
fix extendto argument for geom_highlight when layout="inward_circular" or "dendrogram"

### DIFF
--- a/R/geom_hilight.R
+++ b/R/geom_hilight.R
@@ -103,10 +103,24 @@ GeomHilightRect <- ggproto("GeomHilightRect", Geom,
                            draw_panel = function(self, data, panel_params, coord, linejoin = "mitre") {
                                data$xmax <- data$xmax + data$extend
                                if (!is.null(data$extendto) && !is.na(data$extendto)){
-                                   flag <- data$extendto < data$xmax
-                                   if (any(flag)){
-                                       warning_wrap("extendto is too small for node: ", paste0(data$clade_root_node[flag], collapse="; "),
-                                                    ", keep the original xmax value: ", paste0(data$xmax[flag], collapse="; "), ".")
+                                   # check whether the x of tree is reversed.
+                                   flag1 <- data$xmin < data$xmax
+                                   # check whether extendto is more than xmax 
+                                   flag2 <- data$extendto < data$xmax
+                                   flag <- equals(flag1, flag2)
+                                   if (all(flag1) && any(flag)){
+                                       warning_wrap("extendto ", 
+                                                    paste0(data$extendto[flag], collapse="; "), 
+                                                    ifelse(length(data$extendto[flag])>1, " are", " is"), 
+                                                    " too small for node: ", paste0(data$clade_root_node[flag], collapse="; "),
+                                                    ", keep the original xmax value(s): ", paste0(data$xmax[flag], collapse="; "), ".")
+                                       data$xmax[!flag] <- data$extendto[!flag]
+                                   }else if(!all(flag1) && any(flag)){
+                                       warning_wrap("extendto ", 
+                                                    paste0(data$extendto[flag], collapse="; "), 
+                                                    ifelse(length(data$extendto[flag])>1, " are", " is"),
+                                                    " too big for node: ", paste0(data$clade_root_node[flag], collapse="; "),
+                                                    ", keep the original xmax value(s): ", paste0(data$xmax[flag], collapse="; "), ".")
                                        data$xmax[!flag] <- data$extendto[!flag]
                                    }else{
                                        data$xmax <- data$extendto 


### PR DESCRIPTION
original `extendto` argument don't work when x of tree is reversed. #377 

```
library(ggtree) 

set.seed(1024)

tree <- rtree(20)

p1 <- ggtree(tree)

p2 <- ggtree(
             tree,
             layout = "inward_circular",
             xlim = 8
             )

p3 <- ggtree(tree,
             layout="dendrogram")

p1 <- p1 +
      geom_hilight(mapping=aes(subset=node %in% c(25, 28)), extendto=4) +
      geom_nodelab(mapping=aes(subset=node %in% c(25, 28), label=node))
```
![tree_reverse](https://user-images.githubusercontent.com/17870644/108703059-1165a780-7545-11eb-97c3-1d8650747ac2.png)

```
p2 <- p2 +
      geom_hilight(mapping=aes(subset=node %in% c(25, 28)), extendto=-4) +
      geom_nodelab(mapping=aes(subset=node %in% c(25, 28), label=node))
```
![tree_reverse2](https://user-images.githubusercontent.com/17870644/108703073-188cb580-7545-11eb-88a1-d17ac7e3877d.png)

```
p3 <- p3 +
      geom_hilight(mapping=aes(subset=node %in% c(25, 28)), extendto=-0.5) +
      geom_nodelab(mapping=aes(subset=node %in% c(25, 28), label=node))
```
![tree_reverse3](https://user-images.githubusercontent.com/17870644/108703083-1cb8d300-7545-11eb-9e38-bb99f17348be.png)
