### PR TITLE
added new default tip.order to ggdensitree that is more similar to DensiTree's

### DIFF
--- a/R/ggdensitree.R
+++ b/R/ggdensitree.R
@@ -71,7 +71,7 @@ ggdensitree <- function(data=NULL, mapping=NULL, layout="slanted", tip.order='mo
 	      . %>%
 	        dplyr::filter(isTip) %>%
 	        dplyr::arrange(y) %>%
-	        `$`("label") %>%
+	        dplyr::pull("label") %>%
 	        match(first.label)
 	    ) %>%
 	      do.call(rbind, .) %>%

--- a/man/ggdensitree.Rd
+++ b/man/ggdensitree.Rd
@@ -8,7 +8,7 @@ ggdensitree(
   data = NULL,
   mapping = NULL,
   layout = "slanted",
-  tip.order = "mds_dist",
+  tip.order = "mode",
   align.tips = TRUE,
   jitter = 0,
   ...
@@ -21,7 +21,7 @@ ggdensitree(
 
 \item{layout}{one of 'slanted', 'rectangluar', 'fan', 'circular' or 'radial' (default: 'slanted')}
 
-\item{tip.order}{the order of the tips by a character vector of taxa names; or an integer, N, to order the tips by the order of the tips in the Nth tree; 'mds' to order the tips based on MDS of the path length between the tips;  or 'mds_dist' to order the tips based on MDS of the distance between the tips (default: 'mds_dist')}
+\item{tip.order}{the order of the tips by a character vector of taxa names; or an integer, N, to order the tips by the order of the tips in the Nth tree; 'mode' to order the tips by the most common order; 'mds' to order the tips based on MDS of the path length between the tips;  or 'mds_dist' to order the tips based on MDS of the distance between the tips (default: 'mode')}
 
 \item{align.tips}{TRUE to align trees by their tips and FALSE to align trees by their root (default: TRUE)}
 
@@ -38,40 +38,41 @@ drawing phylogenetic trees from list of phylo objects
 \examples{
 require(ape)
 require(dplyr)
+require(tidyr)
 
-# Plot mutliple trees with aligned tips
+# Plot multiple trees with aligned tips
 trees <- list(read.tree(text="((a:1,b:1):1.5,c:2.5);"), read.tree(text="((a:1,c:1):1,b:2);"));
 ggdensitree(trees) + geom_tiplab()
 
-# Plot multiple trees with aligmned tips with tip labls and separate tree colors
+# Plot multiple trees with aligned tips with tip labels and separate tree colors
 trees.fort <- list(trees[[1]] \%>\% fortify \%>\% mutate(tree="a"), trees[[2]] \%>\% fortify \%>\% mutate(tree="b"));
 ggdensitree(trees.fort, aes(colour=tree)) + geom_tiplab(colour='black')
 
 
 # Generate example data
 set.seed(1)
-trees <- rmtree(5, 10)
-time.trees <- lapply(1:length(trees), function(i) {
- 	tree <- trees[[i]]
+random.trees <- rmtree(5, 10)
+time.trees <- lapply(seq_along(random.trees), function(i) {
+ 	tree <- random.trees[[i]]
  	tree$tip.label <- paste0("t", 1:10)
 	dates <- estimate.dates(tree, 1:10, mu=1, nsteps=1)
 	tree$edge.length <- dates[tree$edge[, 2]] - dates[tree$edge[, 1]]
 	fortify(tree) \%>\% mutate(tree=factor(i, levels=as.character(1:10)))
 })
 
-# Plot multiple trees with aligned tips from muliple time points
+# Plot multiple trees with aligned tips from multiple time points
 ggdensitree(time.trees, aes(colour=tree), tip.order=paste0("t", 1:10)) + geom_tiplab(colour='black')
 
 
 # Read example data
-trees <- read.tree(system.file("examples", "ggdensitree_example.tree", package="ggtree"))
+example.trees <- read.tree(system.file("examples", "ggdensitree_example.tree", package="ggtree"))
 
 # Compute OTU
 grp <- list(A = c("a.t1", "a.t2", "a.t3", "a.t4"), B = c("b.t1", "b.t2", "b.t3", "b.t4"), C = c("c.t1", "c.t2", "c.t3", "c.t4"))
-trees <- lapply(trees, groupOTU, grp)
+otu.trees <- lapply(example.trees, groupOTU, grp)
 
 # Plot multiple trees colored by OTU
-ggdensitree(trees, aes(colour=group), alpha=1/6) + scale_colour_manual(values=c("black", "red", "green", "blue"))
+ggdensitree(otu.trees, aes(colour=group), alpha=1/6, tip.order='mds') + scale_colour_manual(values=c("black", "red", "green", "blue"))
 }
 \author{
 Yu Guangchuang, Bradley R. Jones


### PR DESCRIPTION
I modified `ggdensitree` to add the option of ordering tips by the most commonly seen tip order when you plot the trees individually with `ggtree`. This is more inline with DensiTree's default tip order which chooses the order of the most commonly seen topology. I also made this new tip order `'mode'` the default tip order.