### PR TITLE
remove inhibit.size and use continuous replace 

### DIFF
--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -11,7 +11,7 @@
 ##' 
 ##' some dot arguments:
 ##' \itemize{
-##'    \item \code{continuous} a character, which the aesthethic ('size' or 'color'('colour')) will be continuous. It 
+##'    \item \code{continuous} character, continuous transition for selected aesthethic ('size' or 'color'('colour')). It 
 ##'     should be one of 'color' (or 'colour'), 'size', 'all' and 'none', default is 'none'.
 ##'    \item \code{nsplit} integer, the number of branch blocks divided when 'continuous' is not "none", default is 200.
 ##' }

--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -7,12 +7,13 @@
 ##' @param layout one of 'rectangular', 'dendrogram', 'slanted', 'ellipse', 'roundrect',
 ##' 'fan', 'circular', 'inward_circular', 'radial', 'equal_angle', 'daylight' or 'ape'
 ##' @param multiPhylo logical, whether input data contains multiple phylo class.
+##' @param continuous character, continuous transition for selected aesthethic ('size' 
+##' or 'color'('colour')). It should be one of 'color' (or 'colour'), 'size', 'all' 
+##' and 'none', default is 'none'
 ##' @param ... additional parameter
-##' 
+##'
 ##' some dot arguments:
 ##' \itemize{
-##'    \item \code{continuous} character, continuous transition for selected aesthethic ('size' or 'color'('colour')). It 
-##'     should be one of 'color' (or 'colour'), 'size', 'all' and 'none', default is 'none'.
 ##'    \item \code{nsplit} integer, the number of branch blocks divided when 'continuous' is not "none", default is 200.
 ##' }
 ##' @return tree layer
@@ -27,16 +28,28 @@
 ##' @importFrom ggplot2 aes
 ##' @export
 ##' @author Yu Guangchuang
-geom_tree <- function(mapping=NULL, data=NULL, layout="rectangular", multiPhylo=FALSE, ...) {
+geom_tree <- function(mapping=NULL, data=NULL, layout="rectangular", multiPhylo=FALSE, continuous="none", ...) {
+    if (is.logical(continuous)){
+        warning_wrap('The type of "continuous" argument was changed (v>=2.5.2). Now, 
+                     it should be one of "color" (or "colour"), "size", "all", and "none".')
+        ifelse(continuous,
+               warning_wrap('It was set to TRUE, it should be replaced with "color" (or "colour"), 
+                            this meaning the aesthethic of "color" (or "colour") is continuous.'),
+               warning_wrap('It was set to FALSE, it should be replaced with "none", 
+                            this meaning the aesthethic of "color" (or "colour") or "size" will not be continuous.')
+        )
+        continuous <- ifelse(continuous, "color", "none")
+    }
+    continuous <- match.arg(continuous, c("color", "colour", "size", "none", "all"))
     stat_tree(data=data, mapping=mapping, geom="segment",
-              layout=layout, multiPhylo=multiPhylo, ...)
+              layout=layout, multiPhylo=multiPhylo, continuous=continuous, ...)
 }
 
 
 stat_tree <- function(mapping=NULL, data=NULL, geom="segment", position="identity",
                       layout="rectangular", multiPhylo=FALSE, lineend="round", MAX_COUNT=5,
                       ..., arrow=NULL, rootnode=TRUE, show.legend=NA, inherit.aes=TRUE,
-                      na.rm=TRUE, check.param=TRUE) {
+                      na.rm=TRUE, check.param=TRUE, continuous="none") {
 
     default_aes <- aes_(x=~x, y=~y,node=~node, parent=~parent)
     if (multiPhylo) {
@@ -67,6 +80,7 @@ stat_tree <- function(mapping=NULL, data=NULL, geom="segment", position="identit
                                na.rm = na.rm,
                                arrow = arrow,
                                rootnode = rootnode,
+                               continuous = continuous,
                                ...),
                    check.aes = FALSE
                    ),
@@ -82,6 +96,7 @@ stat_tree <- function(mapping=NULL, data=NULL, geom="segment", position="identit
                                na.rm = na.rm,
                                ## arrow = arrow,
                                rootnode = rootnode,
+                               continuous = continuous,
                                ...),
                    check.aes = FALSE
                    )
@@ -99,6 +114,7 @@ stat_tree <- function(mapping=NULL, data=NULL, geom="segment", position="identit
                           na.rm = na.rm,
                           arrow = arrow,
                           rootnode = rootnode,
+                          continuous = continuous,
                           ...),
               check.aes = FALSE
               )
@@ -116,6 +132,7 @@ stat_tree <- function(mapping=NULL, data=NULL, geom="segment", position="identit
                           na.rm = na.rm,
                           arrow = arrow,
                           rootnode = rootnode,
+                          continuous = continuous,
                           ...),
               check.aes=FALSE
               )
@@ -156,15 +173,6 @@ StatTreeHorizontal <- ggproto("StatTreeHorizontal", Stat,
 
                                           df <- dplyr::filter(df, .data$node != tidytree:::rootnode.tbl_tree(df)$node)
                                       }
-                                      if (is.logical(continuous)){
-                                          warning_wrap('The continuous argument type was changed (v>=2.5.2). Now, it should be one of "color"(or "colour"), "size", "all", and "none".')
-                                          ifelse(continuous, 
-                                                 warning_wrap('It was set to TRUE, it should be replaced with "color"(or "colour"), this meaning the aesthethic of "color"(or "colour") is continuous.'),
-                                                 warning_wrap('It was set to FALSE, it should be replaced with "none", this meaning the aesthethic of "color"(or "colour") or "size" will not be continuous.')
-                                          )
-                                          continuous <- ifelse(continuous, "color", "none")
-                                      }
-                                      continuous <- match.arg(continuous, c("color", "colour", "size", "none", "all"))
                                       if (continuous != "none") {
                                           # using ggnewscale new_scale("color") for multiple color scales
                                           if (length(grep("colour_new", names(df)))==1 && !"colour" %in% names(df)){
@@ -233,10 +241,6 @@ StatTreeVertical <- ggproto("StatTreeVertical", Stat,
                                         df <- dplyr::filter(df, .data$node != rootnode.tbl_tree(df)$node)
                                     }
 
-                                    if (is.logical(continuous)){
-                                        continuous <- ifelse(continuous, "color", "none")
-                                    }
-
                                     if (continuous != "none"){
                                         # using ggnewscale new_scale("color") for multiple color scales
                                         if (length(grep("colour_new", names(df)))==1 && !"colour" %in% names(df)){
@@ -303,15 +307,6 @@ StatTree <- ggproto("StatTree", Stat,
                             if (!rootnode) {
                                 df <- dplyr::filter(df, .data$node != rootnode.tbl_tree(df)$node)
                             }
-                            if (is.logical(continuous)){
-                                warning_wrap('The continuous argument type was changed (v>=2.5.2). Now, it should be one of "color" (or "colour"), "size", "all", and "none".')
-                                ifelse(continuous, 
-                                       warning_wrap('It was set to TRUE, it should be replaced with "color" (or "colour"), this meaning the aesthethic of "color" (or "colour") is continuous.'),
-                                       warning_wrap('It was set to FALSE, it should be replaced with "none", this meaning the aesthethic of "color" (or "colour") or "size" will not be continuous.')
-                                )
-                                continuous <- ifelse(continuous, "color", "none")
-                            }
-                            continuous <- match.arg(continuous, c("color", "colour", "size", "none", "all"))
                             if (continuous != "none") {
                                 # using ggnewscale new_scale("color") for multiple color scales
                                 if (length(grep("colour_new", names(df)))==1 && !"colour" %in% names(df)){

--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -11,18 +11,17 @@
 ##' 
 ##' some dot arguments:
 ##' \itemize{
-##'    \item \code{continuous} a character, which the aesthethic (`size` or `colour`) will be continuous. It 
-##'     should be one of 'color', 'size', 'all' and 'NULL', default is NULL.
-##'    \item \code{nsplit} integer, the number of branch blocks divided when `continuous` is not NULL, default is 200.
-##'    default is TRUE, which is useful to 'aes(size=I(variable))'.
+##'    \item \code{continuous} a character, which the aesthethic ('size' or 'color'('colour')) will be continuous. It 
+##'     should be one of 'color' (or 'colour'), 'size', 'all' and 'none', default is 'none'.
+##'    \item \code{nsplit} integer, the number of branch blocks divided when 'continuous' is not "none", default is 200.
 ##' }
 ##' @return tree layer
 ##' @section Aesthetics:
 #' \code{geom_tree()} understands the following aesthethics:
 ##'     \itemize{
-##'        \item \code{colour} logical, control the color of line, default is black.
+##'        \item \code{color} character, control the color of line, default is black (\code{continuous} is "none").
 ##'        \item \code{linetype} control the type of line, default is 1 (solid).
-##'        \item \code{size} numeric, control the width of line, default is 0.5.
+##'        \item \code{size} numeric, control the width of line, default is 0.5 (\code{continuous} is "none").
 ##'     }
 ##' @importFrom ggplot2 geom_segment
 ##' @importFrom ggplot2 aes
@@ -137,7 +136,7 @@ StatTreeHorizontal <- ggproto("StatTreeHorizontal", Stat,
                                 data
                               },
                               compute_panel = function(self, data, scales, params, layout, lineend,
-                                                       continuous = NULL, rootnode = TRUE, 
+                                                       continuous = "none", rootnode = TRUE, 
                                                        nsplit = 100, extend=0.002 ) {
                                   .fun <- function(data) {
                                       df <- setup_tree_data(data)
@@ -158,13 +157,15 @@ StatTreeHorizontal <- ggproto("StatTreeHorizontal", Stat,
                                           df <- dplyr::filter(df, .data$node != tidytree:::rootnode.tbl_tree(df)$node)
                                       }
                                       if (is.logical(continuous)){
-                                          warning_wrap('The continuous argument type was changed. Now, it should be one of "colour", "size", "all", and "NULL".')
-                                          ifelse(continuous, warning_wrap('It was set to TRUE, it should be replaced with "colour", this meaning the aesthethic of "colour" is continuous.'),
-                                                  warning_wrap('It was set to FALSE, it should be replaced with "NULL", this meaning the aesthethic of "colour" or "size" will not be
-                                                   continuous.'))
-                                          continuous <- switch(continuous, "colour", NULL)
-									  }
-                                      if (!is.null(continuous)) {
+                                          warning_wrap('The continuous argument type was changed (v>=2.5.2). Now, it should be one of "color"(or "colour"), "size", "all", and "none".')
+                                          ifelse(continuous, 
+                                                 warning_wrap('It was set to TRUE, it should be replaced with "color"(or "colour"), this meaning the aesthethic of "color"(or "colour") is continuous.'),
+                                                 warning_wrap('It was set to FALSE, it should be replaced with "none", this meaning the aesthethic of "color"(or "colour") or "size" will not be continuous.')
+                                          )
+                                          continuous <- ifelse(continuous, "color", "none")
+                                      }
+                                      continuous <- match.arg(continuous, c("color", "colour", "size", "none", "all"))
+                                      if (continuous != "none") {
                                           # using ggnewscale new_scale("color") for multiple color scales
                                           if (length(grep("colour_new", names(df)))==1 && !"colour" %in% names(df)){
                                               names(df)[grep("colour_new", names(df))] <- "colour"
@@ -199,10 +200,10 @@ StatTreeHorizontal <- ggproto("StatTreeHorizontal", Stat,
                                       df <- .fun(data)
                                   }
                                   # using ggnewscale new_scale for multiple color or size scales
-                                  if (length(grep("colour_new", names(data)))==1 && !is.null(continuous)){
+                                  if (length(grep("colour_new", names(data)))==1 && continuous != "none"){
                                       names(df)[match("colour", names(df))] <- names(data)[grep("colour_new", names(data))] 
                                   }
-                                  if (length(grep("size_new", names(data)))==1 && !is.null(continuous)){
+                                  if (length(grep("size_new", names(data)))==1 && continuous != "none"){
                                       names(df)[match("size", names(df))] <- names(data)[grep("size_new", names(data))]
                                   }
                                   return(df)
@@ -216,7 +217,7 @@ StatTreeVertical <- ggproto("StatTreeVertical", Stat,
                                 data
                             },
                             compute_panel = function(self, data, scales, params, layout, lineend,
-                                                     continuous = NULL, nsplit=100, 
+                                                     continuous = "none", nsplit=100, 
                                                      extend=0.002, rootnode = TRUE) {
                                 .fun <- function(data) {
                                     df <- setup_tree_data(data)
@@ -233,10 +234,10 @@ StatTreeVertical <- ggproto("StatTreeVertical", Stat,
                                     }
 
                                     if (is.logical(continuous)){
-                                        continuous <- switch(continuous, "colour", NULL)
+                                        continuous <- ifelse(continuous, "color", "none")
                                     }
 
-                                    if (!is.null(continuous)){
+                                    if (continuous != "none"){
                                         # using ggnewscale new_scale("color") for multiple color scales
                                         if (length(grep("colour_new", names(df)))==1 && !"colour" %in% names(df)){
                                             names(df)[grep("colour_new", names(df))] <- "colour"
@@ -269,10 +270,10 @@ StatTreeVertical <- ggproto("StatTreeVertical", Stat,
                                 }
                                 
                                 # using ggnewscale new_scale for multiple color or size scales
-                                if (length(grep("colour_new", names(data)))==1 && !is.null(continuous)){
+                                if (length(grep("colour_new", names(data)))==1 && continuous != "none"){
                                     names(df)[match("colour", names(df))] <- names(data)[grep("colour_new", names(data))]
                                 }
-                                if (length(grep("size_new", names(data)))==1 && !is.null(continuous)){
+                                if (length(grep("size_new", names(data)))==1 && continuous != "none"){
                                     names(df)[match("size", names(df))] <- names(data)[grep("size_new", names(data))]
                                 }
                                 return(df)
@@ -287,7 +288,7 @@ StatTree <- ggproto("StatTree", Stat,
                         data
                     },
                     compute_panel = function(self, data, scales, params, layout, lineend,
-                                             continuous =  NULL, nsplit = 100, 
+                                             continuous =  "none", nsplit = 100, 
                                              extend = 0.002, rootnode = TRUE) {
                         .fun <- function(data) {
                             df <- setup_tree_data(data)
@@ -303,15 +304,15 @@ StatTree <- ggproto("StatTree", Stat,
                                 df <- dplyr::filter(df, .data$node != rootnode.tbl_tree(df)$node)
                             }
                             if (is.logical(continuous)){
-                                warning_wrap('The continuous argument type was changed. Now, it should be one of "colour", "size", "all", and "NULL".')
+                                warning_wrap('The continuous argument type was changed (v>=2.5.2). Now, it should be one of "color" (or "colour"), "size", "all", and "none".')
                                 ifelse(continuous, 
-                                       warning_wrap('It was set to TRUE, it should be replaced with "colour", this meaning the aesthethic of "colour" is continuous.'),
-                                       warning_wrap('It was set to FALSE, it should be replaced with "NULL", this meaning the aesthethic of "colour" or "size" will not be
-                                                    continuous.'))
-                                continuous <- switch(continuous, "colour", NULL)
+                                       warning_wrap('It was set to TRUE, it should be replaced with "color" (or "colour"), this meaning the aesthethic of "color" (or "colour") is continuous.'),
+                                       warning_wrap('It was set to FALSE, it should be replaced with "none", this meaning the aesthethic of "color" (or "colour") or "size" will not be continuous.')
+                                )
+                                continuous <- ifelse(continuous, "color", "none")
                             }
-
-                            if (!is.null(continuous)) {
+                            continuous <- match.arg(continuous, c("color", "colour", "size", "none", "all"))
+                            if (continuous != "none") {
                                 # using ggnewscale new_scale("color") for multiple color scales
                                 if (length(grep("colour_new", names(df)))==1 && !"colour" %in% names(df)){
                                     names(df)[grep("colour_new", names(df))] <- "colour"
@@ -347,10 +348,10 @@ StatTree <- ggproto("StatTree", Stat,
                         }
                         
                         # using ggnewscale new_scale for multiple color or size scales
-                        if (length(grep("colour_new", names(data)))==1 && !is.null(continuous)){
+                        if (length(grep("colour_new", names(data)))==1 && continuous != "none"){
                             names(df)[match("colour", names(df))] <- names(data)[grep("colour_new", names(data))]
                         }
-                        if (length(grep("size_new", names(data)))==1 && !is.null(continuous)){
+                        if (length(grep("size_new", names(data)))==1 && continuous != "none"){
                             names(df)[match("size", names(df))] <- names(data)[grep("size_new", names(data))]
                         }
 
@@ -365,9 +366,9 @@ StatTreeEllipse <- ggproto("StatTreeEllipse", Stat,
                                data
                            },
                            compute_panel = function(self, data, scales, params, layout, lineend, 
-                                                    continuous = NULL, nsplit = 100, 
+                                                    continuous = "none", nsplit = 100, 
                                                     extend = 0.002, rootnode = TRUE){
-                               if (!is.null(continuous) || continuous){
+                               if (continuous !="none" || continuous){
                                    stop("continuous colour or size are not implemented for roundrect or ellipse layout")
                                }
                                df <- StatTree$compute_panel(data = data, scales = scales, 
@@ -506,13 +507,13 @@ setup_data_continuous_color_size_tree <- function(df, nsplit = 100, extend = 0.0
                                                 extend = extend)
         df2$node <- df$node[i]
         # for aes(size=I(variable)) etc.
-        if (continuous %in% c("color", "colour", "Color", "Colour")){
+        if (continuous %in% c("color", "colour")){
             j <- match(c('x', 'xend', 'y', 'yend', 'col', 'col2', 'colour', 'size1', 'size2'), colnames(df))
             df2$size <- NULL
-        }else if (continuous %in% c("size", "Size")){
+        }else if (continuous == "size"){
             j <- match(c("x", "xend", "y", "yend", "col", "col2", "size1", "size2", "size"), colnames(df))
             df2$colour <- NULL
-        }else if (continuous %in% c("all", "All", "ALL")){
+        }else if (continuous == "all"){
             j <- match(c('x', 'xend', 'y', 'yend', 'col', 'col2', 'colour', 'size1', 'size2', 'size'), colnames(df))
         }
         j <- j[!is.na(j)]

--- a/R/ggtree.R
+++ b/R/ggtree.R
@@ -27,7 +27,7 @@
 ##' @importFrom ggplot2 coord_polar
 ##' @export
 ##' @author Yu Guangchuang
-##' @seealso [ape::ladderize()]
+##' @seealso [geom_tree()]
 ##' @references 1. G Yu, TTY Lam, H Zhu, Y Guan (2018). Two methods for mapping and visualizing associated data
 ##' on phylogeny using ggtree. Molecular Biology and Evolution, 35(2):3041-3043.
 ##' <https://doi.org/10.1093/molbev/msy194>

--- a/man/geom_tree.Rd
+++ b/man/geom_tree.Rd
@@ -26,9 +26,9 @@ geom_tree(
 
 some dot arguments:
 \itemize{
-\item \code{continuous} logical, whether the aesthethic of \code{size} or \code{color} is continuous, default is FALSE.
-\item \code{nsplit} integer, the number of branch blocks divided when \code{continuous} is TRUE, default is 200.
-\item \code{inhibit.size} logical, whether inhibit the size when it was mapped to a variable in aesthetic and item \code{continuous} is TRUE,
+\item \code{continuous} a character, which the aesthethic (\code{size} or \code{colour}) will be continuous. It
+should be one of 'color', 'size', 'all' and 'NULL', default is NULL.
+\item \code{nsplit} integer, the number of branch blocks divided when \code{continuous} is not NULL, default is 200.
 default is TRUE, which is useful to 'aes(size=I(variable))'.
 }}
 }

--- a/man/geom_tree.Rd
+++ b/man/geom_tree.Rd
@@ -9,6 +9,7 @@ geom_tree(
   data = NULL,
   layout = "rectangular",
   multiPhylo = FALSE,
+  continuous = "none",
   ...
 )
 }
@@ -22,12 +23,14 @@ geom_tree(
 
 \item{multiPhylo}{logical, whether input data contains multiple phylo class.}
 
+\item{continuous}{character, continuous transition for selected aesthethic ('size'
+or 'color'('colour')). It should be one of 'color' (or 'colour'), 'size', 'all'
+and 'none', default is 'none'}
+
 \item{...}{additional parameter
 
 some dot arguments:
 \itemize{
-\item \code{continuous} a character, which the aesthethic ('size' or 'color'('colour')) will be continuous. It
-should be one of 'color' (or 'colour'), 'size', 'all' and 'none', default is 'none'.
 \item \code{nsplit} integer, the number of branch blocks divided when 'continuous' is not "none", default is 200.
 }}
 }

--- a/man/geom_tree.Rd
+++ b/man/geom_tree.Rd
@@ -26,10 +26,9 @@ geom_tree(
 
 some dot arguments:
 \itemize{
-\item \code{continuous} a character, which the aesthethic (\code{size} or \code{colour}) will be continuous. It
-should be one of 'color', 'size', 'all' and 'NULL', default is NULL.
-\item \code{nsplit} integer, the number of branch blocks divided when \code{continuous} is not NULL, default is 200.
-default is TRUE, which is useful to 'aes(size=I(variable))'.
+\item \code{continuous} a character, which the aesthethic ('size' or 'color'('colour')) will be continuous. It
+should be one of 'color' (or 'colour'), 'size', 'all' and 'none', default is 'none'.
+\item \code{nsplit} integer, the number of branch blocks divided when 'continuous' is not "none", default is 200.
 }}
 }
 \value{
@@ -42,9 +41,9 @@ add tree layer
 
 \code{geom_tree()} understands the following aesthethics:
 \itemize{
-\item \code{colour} logical, control the color of line, default is black.
+\item \code{color} character, control the color of line, default is black (\code{continuous} is "none").
 \item \code{linetype} control the type of line, default is 1 (solid).
-\item \code{size} numeric, control the width of line, default is 0.5.
+\item \code{size} numeric, control the width of line, default is 0.5 (\code{continuous} is "none").
 }
 }
 

--- a/man/ggtree.Rd
+++ b/man/ggtree.Rd
@@ -58,9 +58,9 @@ right-hand side? See \code{\link[ape:ladderize]{ape::ladderize()}} for more info
 
 some dot arguments:
 \itemize{
-\item \code{continuous} logical, whether the aesthethic of \code{size} or \code{color} is continuous, default is FALSE.
-\item \code{nsplit} integer, the number of branch blocks divided when \code{continuous} is TRUE, default is 200.
-\item \code{inhibit.size} logical, whether inhibit the size when it was mapped to a variable in aesthetic and item \code{continuous} is TRUE,
+\item \code{continuous} a character, which the aesthethic (\code{size} or \code{colour}) will be continuous. It
+should be one of 'color', 'size', 'all' and 'NULL', default is NULL.
+\item \code{nsplit} integer, the number of branch blocks divided when \code{continuous} is not NULL, default is 200.
 default is TRUE, which is useful to 'aes(size=I(variable))'.
 }}
 }

--- a/man/ggtree.Rd
+++ b/man/ggtree.Rd
@@ -58,8 +58,6 @@ right-hand side? See \code{\link[ape:ladderize]{ape::ladderize()}} for more info
 
 some dot arguments:
 \itemize{
-\item \code{continuous} a character, which the aesthethic ('size' or 'color'('colour')) will be continuous. It
-should be one of 'color' (or 'colour'), 'size', 'all' and 'none', default is 'none'.
 \item \code{nsplit} integer, the number of branch blocks divided when 'continuous' is not "none", default is 200.
 }}
 }
@@ -91,7 +89,7 @@ other associated data. Methods in Ecology and Evolution, 8(1):28-36.
 }
 }
 \seealso{
-\code{\link[ape:ladderize]{ape::ladderize()}}
+\code{\link[=geom_tree]{geom_tree()}}
 }
 \author{
 Yu Guangchuang

--- a/man/ggtree.Rd
+++ b/man/ggtree.Rd
@@ -58,10 +58,9 @@ right-hand side? See \code{\link[ape:ladderize]{ape::ladderize()}} for more info
 
 some dot arguments:
 \itemize{
-\item \code{continuous} a character, which the aesthethic (\code{size} or \code{colour}) will be continuous. It
-should be one of 'color', 'size', 'all' and 'NULL', default is NULL.
-\item \code{nsplit} integer, the number of branch blocks divided when \code{continuous} is not NULL, default is 200.
-default is TRUE, which is useful to 'aes(size=I(variable))'.
+\item \code{continuous} a character, which the aesthethic ('size' or 'color'('colour')) will be continuous. It
+should be one of 'color' (or 'colour'), 'size', 'all' and 'none', default is 'none'.
+\item \code{nsplit} integer, the number of branch blocks divided when 'continuous' is not "none", default is 200.
 }}
 }
 \value{


### PR DESCRIPTION
`inhibit.size` in this [request](https://github.com/YuLab-SMU/ggtree/pull/385) was remove, and then use `continuous` to replace it, `continuous` should be one of 'color', 'size', 'all' and NULL. But if it is logical, if it is TRUE, it will be replaced with 'color' in the internal. if it is FALSE, it will be replaced with NULL. 

```
library(ggtree)                                                                                                                                                                             
library(treeio)
library(patchwork)
 
set.seed(1024)
 
tr <- rtree(40)
 
dat <- data.frame(label=tr$tip.label, trait=abs(rnorm(40, mean=3, sd=1)))
 
tr <- full_join(tr, dat, by="label") %>% as_tibble()
 
tr$width <- ifelse(is.na(tr$trait), 1, 2)
 
tr <- tr %>% as.treedata()
 
p2 <- ggtree(tr,
             aes(color=trait, size=I(width)),
             continuous="all"
             ) +
      ggnewscale::new_scale("color") +
      ggnewscale::new_scale("color") +
      ggnewscale::new_scale("size")
p2
```
<img width="634" alt="test1" src="https://user-images.githubusercontent.com/17870644/113483199-d015cf80-94d4-11eb-98c0-fef27f21612a.png">

``` 
p3 <- ggtree(tr,
             layout="daylight",
             aes(color=trait, size=I(width)),
             continuous="color")
 
p3
```
<img width="619" alt="test2" src="https://user-images.githubusercontent.com/17870644/113483204-d73cdd80-94d4-11eb-808a-25e3061f4d70.png">
