### PR TITLE
The optimization of internal function of geom_tiplab

### DIFF
--- a/R/geom_nodelab.R
+++ b/R/geom_nodelab.R
@@ -5,19 +5,21 @@
 ##' @param mapping aes mapping
 ##' @param nudge_x horizontal adjustment to nudge label
 ##' @param nudge_y vertical adjustment to nudge label
-##' @param geom one of 'text', 'label', 'image' and 'phylopic'
+##' @param geom one of 'text', "shadowtext", 'label', 'image' and 'phylopic'
 ##' @param hjust horizontal alignment, one of 0, 0.5 or 1
-##' @param ... additional parameters
+##' @param ... additional parameters, see also 
+##' the additional parameters of [geom_tiplab()].
+##' @seealso [geom_tiplab()]
 ##' @return geom layer
 ##' @export
 ##' @author Guangchuang Yu
 geom_nodelab <- function(mapping = NULL, nudge_x = 0, nudge_y = 0, geom = "text", hjust = 0.5, ...) {
-    self_mapping <- aes_(subset = ~!isTip)
-    if (is.null(mapping)) {
-        mapping <- self_mapping
-    } else {
-        mapping <- modifyList(self_mapping, mapping)
-    }
+    #self_mapping <- aes_(subset = ~!isTip)
+    #if (is.null(mapping)) {
+    #    mapping <- self_mapping
+    #} else {
+    #    mapping <- modifyList(self_mapping, mapping)
+    #}
 
     geom_tiplab(mapping, offset = nudge_x, nudge_y = nudge_y, geom = geom, hjust = hjust, ...)
 }

--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -122,10 +122,10 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
     params <- list(...)
     if ("nudge_x" %in% names(params)){
         if (offset != 0){
-            warning_wrap("The nudge_x and offset argument both was provided.
+            warning_wrap("Both nudge_x and offset arguments are provided.
                          Because they all adjust the horizontal offset of labels,
-                         and the 'nudge_x' is consistency with 'ggplot2'. The
-                         'nudge_x' will be predetermined, 'offset' will be deprecated.")
+                         and the 'nudge_x' is consistent with 'ggplot2'. The
+                         'offset' will be deprecated here and only the 'nudge_x' will be used.")
         }
         offset <- params$nudge_x
         params$nudge_x <- NULL

--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -4,7 +4,8 @@
 ##' @title geom_tiplab
 ##' @param mapping aes mapping
 ##' @param hjust horizontal adjustment
-##' @param offset tiplab offset
+##' @param offset tiplab offset, horizontal 
+##' adjustment to nudge tip labels, default is 0.
 ##' @param align align tip lab or not, logical
 ##' @param linetype linetype for adding line if align = TRUE
 ##' @param linesize line size of line if align = TRUE
@@ -25,8 +26,8 @@
 ##'     \item \code{fontface} the font face of text, default is 1 (plain), others are 
 ##'      2 (bold), 3 (italic), 4 (bold.italic).
 ##'     \item \code{lineheight} The height of a line as a multiple of the size of text, default is 1.2 .
-##'     \item \code{nudge_x} horizontal adjustment, default is 0.
-##'     \item \code{nudge_y}  vertical adjustment, default is 0.
+##'     \item \code{nudge_x} horizontal adjustment to nudge labels, default is 0. 
+##'     \item \code{nudge_y}  vertical adjustment to nudge labels, default is 0.
 ##'     \item \code{check.overlap} if TRUE, text that overlaps previous text in the same layer 
 ##'      will not be plotted.
 ##'     \item \code{parse} if TRUE, the labels will be parsed into expressions, if it is 'emoji', the labels
@@ -44,7 +45,7 @@
 ##'     \item \code{fontface} the font face of text, default is 1 (plain), others are
 ##'     2 (bold), 3 (italic), 4 (bold.italic).
 ##'     \item \code{lineheight} The height of a line as a multiple of the size of text, default is 1.2.
-##'     \item \code{nudge_x} horizontal adjustment, default is 0.
+##'     \item \code{nudge_x} horizontal adjustment to nudge labels, default is 0.
 ##'     \item \code{nudge_y}  vertical adjustment, default is 0.
 ##'     \item \code{check.overlap} if TRUE, text that overlaps previous text in the same layer
 ##'      will not be plotted.
@@ -119,6 +120,16 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
                                     linetype = "dotted", linesize=0.5, geom="text",  
                                     offset=0, family = "", fontface = "plain", ...) {
     params <- list(...)
+    if ("nudge_x" %in% names(params)){
+        if (offset != 0){
+            warning_wrap("The nudge_x and offset argument both was provided.
+                         Because they all adjust the horizontal offset of labels,
+                         and the 'nudge_x' is consistency with 'ggplot2'. The
+                         'nudge_x' will be predetermined, 'offset' will be deprecated.")
+        }
+        offset <- params$nudge_x
+        params$nudge_x <- NULL
+    }
     geom <- match.arg(geom, c("text", "label", "shadowtext", "image", "phylopic"))
     if (geom == "text") {
         label_geom <- geom_text2
@@ -178,12 +189,12 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
     params[["nodelab"]] <- NULL
     imageparams <- list(mapping=text_mapping, hjust = hjust, nudge_x = offset, stat = StatTreeData)
     imageparams <- extract_params(imageparams, params, c("size", "alpha", "color", "colour", "image", 
-                                                         "angle", "nudge_x", "inherit.aes", "by", "show.legend",
+                                                         "angle", "position", "inherit.aes", "by", "show.legend",
                                                          "image_fun", ".fun", "asp", "nudge_y", "height", "na.rm")) 
     labelparams <- list(mapping=text_mapping, hjust = hjust, nudge_x = offset, stat = StatTreeData, family = family, fontface = fontface)
     labelparams <- extract_params(labelparams, params, 
                                   c("size", "alpha", "vjust", "color", "colour", "angle", "alpha", 
-                                    "lineheight", "fill", "nudge_x", "nudge_y", "show.legend", "check_overlap",
+                                    "lineheight", "fill", "position", "nudge_y", "show.legend", "check_overlap",
                                     "parse", "inherit.aes", "na.rm", "label.r", "label.size", "label.padding",
                                     "bg.colour", "bg.r"))
     list(

--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -363,7 +363,7 @@ StatTreeEllipse <- ggproto("StatTreeEllipse", Stat,
                            compute_panel = function(self, data, scales, params, layout, lineend, 
                                                     continuous = "none", nsplit = 100, 
                                                     extend = 0.002, rootnode = TRUE){
-                               if (continuous !="none" || continuous){
+                               if (continuous !="none"){
                                    stop("continuous colour or size are not implemented for roundrect or ellipse layout")
                                }
                                df <- StatTree$compute_panel(data = data, scales = scales, 

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -218,7 +218,7 @@ ggplot_add.tiplab <- function(object, plot, object_name) {
         layout == "inward_circular") {
         ly <- do.call(geom_tiplab_circular, object)
     } else {
-        object$nodelab <- NULL
+        #object$nodelab <- NULL
         ly <- do.call(geom_tiplab_rectangular, object)
     }
     ggplot_add(ly, plot, object_name)

--- a/man/geom_nodelab.Rd
+++ b/man/geom_nodelab.Rd
@@ -20,17 +20,21 @@ geom_nodelab(
 
 \item{nudge_y}{vertical adjustment to nudge label}
 
-\item{geom}{one of 'text', 'label', 'image' and 'phylopic'}
+\item{geom}{one of 'text', "shadowtext", 'label', 'image' and 'phylopic'}
 
 \item{hjust}{horizontal alignment, one of 0, 0.5 or 1}
 
-\item{...}{additional parameters}
+\item{...}{additional parameters, see also
+the additional parameters of \code{\link[=geom_tiplab]{geom_tiplab()}}.}
 }
 \value{
 geom layer
 }
 \description{
 add node label layer
+}
+\seealso{
+\code{\link[=geom_tiplab]{geom_tiplab()}}
 }
 \author{
 Guangchuang Yu

--- a/man/geom_nodelab2.Rd
+++ b/man/geom_nodelab2.Rd
@@ -20,11 +20,12 @@ geom_nodelab2(
 
 \item{nudge_y}{vertical adjustment to nudge label}
 
-\item{geom}{one of 'text', 'label', 'image' and 'phylopic'}
+\item{geom}{one of 'text', "shadowtext", 'label', 'image' and 'phylopic'}
 
 \item{hjust}{horizontal alignment, one of 0, 0.5 or 1}
 
-\item{...}{additional parameters}
+\item{...}{additional parameters, see also
+the additional parameters of \code{\link[=geom_tiplab]{geom_tiplab()}}.}
 }
 \value{
 node label layer

--- a/man/geom_tiplab.Rd
+++ b/man/geom_tiplab.Rd
@@ -29,7 +29,8 @@ geom_tiplab(
 
 \item{geom}{one of 'text', 'label', 'shadowtext', 'image' and 'phylopic'}
 
-\item{offset}{tiplab offset}
+\item{offset}{tiplab offset, horizontal
+adjustment to nudge tip labels, default is 0.}
 
 \item{as_ylab}{display tip labels as y-axis label, only works for rectangular and dendrogram layouts}
 
@@ -48,8 +49,8 @@ The following parameters for geom="text".
 \item \code{fontface} the font face of text, default is 1 (plain), others are
 2 (bold), 3 (italic), 4 (bold.italic).
 \item \code{lineheight} The height of a line as a multiple of the size of text, default is 1.2 .
-\item \code{nudge_x} horizontal adjustment, default is 0.
-\item \code{nudge_y}  vertical adjustment, default is 0.
+\item \code{nudge_x} horizontal adjustment to nudge labels, default is 0.
+\item \code{nudge_y}  vertical adjustment to nudge labels, default is 0.
 \item \code{check.overlap} if TRUE, text that overlaps previous text in the same layer
 will not be plotted.
 \item \code{parse} if TRUE, the labels will be parsed into expressions, if it is 'emoji', the labels
@@ -67,7 +68,7 @@ The following parameters for geom="label".
 \item \code{fontface} the font face of text, default is 1 (plain), others are
 2 (bold), 3 (italic), 4 (bold.italic).
 \item \code{lineheight} The height of a line as a multiple of the size of text, default is 1.2.
-\item \code{nudge_x} horizontal adjustment, default is 0.
+\item \code{nudge_x} horizontal adjustment to nudge labels, default is 0.
 \item \code{nudge_y}  vertical adjustment, default is 0.
 \item \code{check.overlap} if TRUE, text that overlaps previous text in the same layer
 will not be plotted.

--- a/man/geom_tiplab.Rd
+++ b/man/geom_tiplab.Rd
@@ -33,7 +33,75 @@ geom_tiplab(
 
 \item{as_ylab}{display tip labels as y-axis label, only works for rectangular and dendrogram layouts}
 
-\item{...}{additional parameter}
+\item{...}{additional parameter
+
+additional parameters can refer the following parameters.
+
+The following parameters for geom="text".
+\itemize{
+\item \code{size} control the size of tip labels, default is 3.88.
+\item \code{colour} control the colour of tip labels, default is "black".
+\item \code{angle} control the angle of tip labels, default is 0.
+\item \code{vjust} A numeric vector specifying vertical justification, default is 0.5.
+\item \code{alpha} the transparency of text, default is NA.
+\item \code{family} the family of text, default is 'sans'.
+\item \code{fontface} the font face of text, default is 1 (plain), others are
+2 (bold), 3 (italic), 4 (bold.italic).
+\item \code{lineheight} The height of a line as a multiple of the size of text, default is 1.2 .
+\item \code{nudge_x} horizontal adjustment, default is 0.
+\item \code{nudge_y}  vertical adjustment, default is 0.
+\item \code{check.overlap} if TRUE, text that overlaps previous text in the same layer
+will not be plotted.
+\item \code{parse} if TRUE, the labels will be parsed into expressions, if it is 'emoji', the labels
+will be parsed into emojifont.
+}
+
+The following parameters for geom="label".
+\itemize{
+\item \code{size} the size of tip labels, default is 3.88.
+\item \code{colour} the colour of tip labels, default is "black".
+\item \code{fill} the colour of rectangular box of labels, default is "white".
+\item \code{vjust} numeric vector specifying vertical justification, default is 0.5.
+\item \code{alpha} the transparency of labels, default is NA.
+\item \code{family} the family of text, default is 'sans'.
+\item \code{fontface} the font face of text, default is 1 (plain), others are
+2 (bold), 3 (italic), 4 (bold.italic).
+\item \code{lineheight} The height of a line as a multiple of the size of text, default is 1.2.
+\item \code{nudge_x} horizontal adjustment, default is 0.
+\item \code{nudge_y}  vertical adjustment, default is 0.
+\item \code{check.overlap} if TRUE, text that overlaps previous text in the same layer
+will not be plotted.
+\item \code{parse} if TRUE, the labels will be parsed into expressions, if it is 'emoji', the labels
+will be parsed into emojifont.
+\item \code{label.padding} Amount of padding around label, default is 'unit(0.25, "lines")'.
+\item \code{label.r} Radius of rounded corners, default is 'unit(0.15, "lines")'.
+\item \code{label.size} Size of label border, in mm, default is 0.25.
+}
+
+The following parameters for geom="shadowtext", some parameters are like to geom="text".
+\itemize{
+\item \code{bg.colour} the background colour of text, default is "black".
+\item \code{bg.r} the width of background of text, default is 0.1 .
+}
+
+The following parameters for geom="image" or geom="phylopic".
+\itemize{
+\item \code{image} the image file path for geom='image', but when geom='phylopic',
+it should be the uid of phylopic databases.
+\item \code{size} the image size, default is 0.05.
+\item \code{colour} the color of image, default is NULL.
+\item \code{alpha} the transparency of image, default is 0.8.
+}
+
+The following parameters for the line when align = TRUE.
+\itemize{
+\item \code{colour} the colour of line, default is 'black'.
+\item \code{alpha} the transparency of line, default is NA.
+\item \code{arrow} specification for arrow heads,
+as created by arrow(), default is NULL.
+\item \code{arrow.fill} fill color to usse for the arrow head (if closed),
+default is 'NULL', meaning use 'colour' aesthetic.
+}}
 }
 \value{
 tip label layer


### PR DESCRIPTION
+ The original internal function of `geom_tiplab` can subset the tip labels, but when the `mapping` argument is provided, and the `subset`  is also in the aesthetics. Users should assign `subset` to `their condition & isTip` in rectangular layout #391. This pull request fixed the problem, the `subset=their condition` can work after fixing. And the `geom_nodelab`, which depends on `geom_tiplab`, is also considered.

+ update the `rd` of `geom_tiplab`

```
> library(ggtree)
ggtree v2.5.2  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics, 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> library(ape)
> set.seed(13)
> tree <- rtree(10)
> tree <- makeNodeLabel(tree)
> ggtree(tree) +
      geom_tiplab(aes(subset=node<2),fontface="bold") +
      geom_tiplab(aes(subset=node>1)) +
      geom_nodelab(color="blue", nudge_y=1)
```
![捕获](https://user-images.githubusercontent.com/17870644/114701430-63f95e00-9d55-11eb-94af-c78545050a93.PNG)

```
ggtree(tree, layout="circular") +
        geom_tiplab(aes(subset=node<2),fontface="bold") +
        geom_tiplab(aes(subset=node>1)) +
        geom_nodelab(color="blue", nudge_x=0.2)
```
![捕获2](https://user-images.githubusercontent.com/17870644/114701548-88edd100-9d55-11eb-9b8f-b29ac312547b.PNG)
