### PR TITLE
fix ape layout branch.length

### DIFF
--- a/R/tree-utilities.R
+++ b/R/tree-utilities.R
@@ -1200,7 +1200,7 @@ layoutApe <- function(model, branch.length="branch.length") {
 
 	df <- as_tibble(model) %>%
 		mutate(isTip = ! .data$node %in% .data$parent)
-	df$branch.length <- edge.length[df$node] # for cladogram
+	#df$branch.length <- edge.length[df$node] # for cladogram
 
 	# unrooted layout from cran/ape
 	M <- ape::unrooted.xy(Ntip(tree),


### PR DESCRIPTION
+ The order of `node` of `tbl_tree` class contained `labels` is not consistent with the `edge.length` of `phylo` class,
    so I think this code should be commented out. 
+ the related issue #402 

```
> library(ggtree)
ggtree v3.1.0  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics, 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> set.seed(123)
> tr <- rtree(10)
> p <- ggtree(tr, layout="ape")
> p1 <- p + geom_nodelab(aes(label=node), color="red") + geom_text(aes(x=branch, label = round(branch.length, 1)), nudge_x=0.1) + geom_tiplab(color="blue")
> f1 <- f + geom_nodelab(aes(label=node), nudge_x=0.1, color="red") + geom_text(aes(x=branch, label = round(branch.length, 1)), nudge_y=0.1) + geom_tiplab(color="blue")
> p1 + f1
```
![捕获](https://user-images.githubusercontent.com/17870644/119432552-1d7d2300-bd47-11eb-8791-b947cc600d5c.PNG)
