### PR TITLE
update geom_tiplab for better compatibility with geom_nodelab

### DIFF
--- a/R/geom_nodelab.R
+++ b/R/geom_nodelab.R
@@ -21,5 +21,7 @@ geom_nodelab <- function(mapping = NULL, nudge_x = 0, nudge_y = 0, geom = "text"
     #    mapping <- modifyList(self_mapping, mapping)
     #}
 
-    geom_tiplab(mapping, offset = nudge_x, nudge_y = nudge_y, geom = geom, hjust = hjust, ...)
+    p <- geom_tiplab(mapping, offset = nudge_x, nudge_y = nudge_y, geom = geom, hjust = hjust, ...)
+    p$nodelab <- TRUE
+    return (p)
 }

--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -92,8 +92,8 @@
 geom_tiplab <- function(mapping=NULL, hjust = 0,  align = FALSE, linetype = "dotted",
                         linesize=0.5, geom="text",  offset=0, as_ylab = FALSE, ...) {
     #####in order to check whether it is geom_nodelab
-    .call <- match.call(call = sys.call(sys.parent(1)))
-    nodelab <- ifelse(as.list(.call)[[1]]=="geom_nodelab", TRUE, FALSE)
+    #.call <- match.call(call = sys.call(sys.parent(1)))
+    #nodelab <- ifelse(as.list(.call)[[1]]=="geom_nodelab", TRUE, FALSE)
     #####
     structure(list(mapping = mapping,
                    hjust = hjust,
@@ -103,7 +103,7 @@ geom_tiplab <- function(mapping=NULL, hjust = 0,  align = FALSE, linetype = "dot
                    geom = geom,
                    offset = offset,
                    as_ylab = as_ylab,
-                   nodelab = nodelab,
+                   #nodelab = nodelab,
                    ...),
               class = "tiplab")
 }


### PR DESCRIPTION
The `match.call()` was introduced in [the commit](https://github.com/YuLab-SMU/ggtree/pull/353) to detect when `geom_tiplab` is being called via `geom_nodelab`.

But it might generate the issues in shiny env #404.

Since the internal function of `geom_tiplab` has been also updated in [the commit](https://github.com/YuLab-SMU/ggtree/pull/392), it can be removed.


