### PR TITLE
new geom_nodelab and geom_tiplab

### DIFF
--- a/R/geom_nodelab.R
+++ b/R/geom_nodelab.R
@@ -7,21 +7,19 @@
 ##' @param nudge_y vertical adjustment to nudge label
 ##' @param geom one of 'text', "shadowtext", 'label', 'image' and 'phylopic'
 ##' @param hjust horizontal alignment, one of 0, 0.5 or 1
+##' @param node a character indicating which node labels will be displayed,
+##' it should be one of 'internal', 'external' and 'all'. If it is set to 'internal'
+##' will display internal node labels, 'external' will display the tip labels,
+##' and 'all' will display internal node and tip labels.
 ##' @param ... additional parameters, see also 
 ##' the additional parameters of [geom_tiplab()].
 ##' @seealso [geom_tiplab()]
 ##' @return geom layer
 ##' @export
 ##' @author Guangchuang Yu
-geom_nodelab <- function(mapping = NULL, nudge_x = 0, nudge_y = 0, geom = "text", hjust = 0.5, ...) {
-    #self_mapping <- aes_(subset = ~!isTip)
-    #if (is.null(mapping)) {
-    #    mapping <- self_mapping
-    #} else {
-    #    mapping <- modifyList(self_mapping, mapping)
-    #}
+geom_nodelab <- function(mapping = NULL, nudge_x = 0, nudge_y = 0, geom = "text", hjust = 0.5, node="internal",...) {
 
     p <- geom_tiplab(mapping, offset = nudge_x, nudge_y = nudge_y, geom = geom, hjust = hjust, ...)
-    p$nodelab <- TRUE
+    p$node <- match.arg(node, c("internal", "external", "all"))
     return (p)
 }

--- a/man/geom_nodelab.Rd
+++ b/man/geom_nodelab.Rd
@@ -10,6 +10,7 @@ geom_nodelab(
   nudge_y = 0,
   geom = "text",
   hjust = 0.5,
+  node = "internal",
   ...
 )
 }
@@ -23,6 +24,11 @@ geom_nodelab(
 \item{geom}{one of 'text', "shadowtext", 'label', 'image' and 'phylopic'}
 
 \item{hjust}{horizontal alignment, one of 0, 0.5 or 1}
+
+\item{node}{a character indicating which node labels will be displayed,
+it should be one of 'internal', 'external' and 'all'. If it is set to 'internal'
+will display internal node labels, 'external' will display the tip labels,
+and 'all' will display internal node and tip labels.}
 
 \item{...}{additional parameters, see also
 the additional parameters of \code{\link[=geom_tiplab]{geom_tiplab()}}.}


### PR DESCRIPTION
new version `geom_nodelab` and `geom_tiplab`

#407 

```
library(ggtree)
library(ape)
set.seed(13)
tree <- rtree(10)
tree <- makeNodeLabel(tree)                                                                                                                                                                             
p <- ggtree(
         tree
     )

p1 <- p +
      geom_tiplab(aes(subset=node<2),fontface="bold") +
      geom_tiplab(aes(subset=node>1)) +
      geom_nodelab(color="blue", nudge_x=0.1)

p2 <- p +
      geom_nodelab(aes(subset=node<2),fontface="bold", hjust=0, node="external") +
      geom_nodelab(aes(subset=node>1), node="external", hjust=0) +
      geom_nodelab(color="blue", nudge_x=0.1)

xx <- p1/p2
xx
```
![test](https://user-images.githubusercontent.com/17870644/120098710-0cc71580-c16a-11eb-8136-424411911f7c.png)
