### PR TITLE
Add branch.y (and branch.x = branch) in calculate_branch_mid() for positioning on branches in unrooted layouts

### DIFF
--- a/R/tree-utilities.R
+++ b/R/tree-utilities.R
@@ -1154,10 +1154,13 @@ add_angle_slanted <- function(res) {
 
 calculate_branch_mid <- function(res) {
     res$branch <- with(res, (x[match(parent, node)] + x)/2)
+    res$branch.y <- with(res, (y[match(parent, node)] + y)/2)
     if (!is.null(res[['branch.length']])) {
         res$branch.length[is.na(res$branch.length)] <- 0
     }
     res$branch[is.na(res$branch)] <- 0
+    res$branch.x <- res$branch
+    res$branch.y[is.na(res$branch.y)] <- 0
     return(res)
 }
 


### PR DESCRIPTION
Addresses #402. The commit introduces `branch.y` as well as `branch.x` (as an alias for `branch` for the sake of symmetry).