### PR TITLE
add branch.x and branch.y for unrooted layout

### DIFF
--- a/R/clade-functions.R
+++ b/R/clade-functions.R
@@ -120,7 +120,7 @@ collapse.ggtree <- function(x=NULL, node, mode = "none", clade_name = NULL, ...)
         df <- reassign_y_from_node_to_root(df, node)
         
         ## re-calculate branch mid position
-        df <- calculate_branch_mid(df)
+        df <- calculate_branch_mid(df, layout=get_layout(tree_view))
 
         ii <- which(!is.na(df$x))
         df$angle[ii] <- calculate_angle(df[ii,])$angle
@@ -217,7 +217,7 @@ expand <- function(tree_view=NULL, node) {
         df[pp, "y"] <- mean(df$y[j])
         
         ## re-calculate branch mid position
-        df <- calculate_branch_mid(df)
+        df <- calculate_branch_mid(df, layout=get_layout(tree_view))
 
         tree_view$data <- calculate_angle(df)
     } else {
@@ -400,7 +400,7 @@ scaleClade <- function(tree_view=NULL, node, scale=1, vertical_only=TRUE) {
     df <- reassign_y_from_node_to_root(df, node)
 
     ## re-calculate branch mid position
-    df <- calculate_branch_mid(df)
+    df <- calculate_branch_mid(df, layout=get_layout(tree_view))
 
     tree_view$data <- calculate_angle(df)
 

--- a/R/geom_hilight.R
+++ b/R/geom_hilight.R
@@ -102,7 +102,7 @@ GeomHilightRect <- ggproto("GeomHilightRect", Geom,
                            draw_key = draw_key_polygon,
                            draw_panel = function(self, data, panel_params, coord, linejoin = "mitre") {
                                data$xmax <- data$xmax + data$extend
-                               if (!is.null(data$extendto) && !is.na(data$extendto)){
+                               if (!any(is.null(data$extendto)) && !any(is.na(data$extendto))){
                                    # check whether the x of tree is reversed.
                                    flag1 <- data$xmin < data$xmax
                                    # check whether extendto is more than xmax 

--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -49,7 +49,7 @@ fortify.phylo <- function(model, data,
     }
 
     ## add branch mid position
-    res <- calculate_branch_mid(res)
+    res <- calculate_branch_mid(res, layout=layout)
 
     if (!is.null(mrsd)) {
         res <- scaleX_by_time_from_mrsd(res, mrsd, as.Date)

--- a/R/tree-utilities.R
+++ b/R/tree-utilities.R
@@ -1152,12 +1152,19 @@ add_angle_slanted <- function(res) {
 }
 
 
-calculate_branch_mid <- function(res) {
+calculate_branch_mid <- function(res, layout) {
+    if (layout %in% c("equal_angle", "daylight", "ape")){
+        res$branch.y <- with(res, (y[match(parent, node)] + y)/2)
+        res$branch.y[is.na(res$branch.y)] <- 0
+    }
     res$branch <- with(res, (x[match(parent, node)] + x)/2)
     if (!is.null(res[['branch.length']])) {
         res$branch.length[is.na(res$branch.length)] <- 0
     }
     res$branch[is.na(res$branch)] <- 0
+    if (layout %in% c("equal_angle", "daylight", "ape")){
+        res$branch.x <- res$branch
+    }
     return(res)
 }
 


### PR DESCRIPTION
+ This request made a small modification to #412.
  - The branch.x and branch.y will be calculated when layout is ape, unrooted etc.
  
  ```
  > library(ggtree)
  > set.seed(123)
  > tr <- rtree(10)
  > ggtree(tr, layout="ape") + geom_text2(aes(label=node, x=branch.x, y=branch.y))  
  ```
![test](https://user-images.githubusercontent.com/17870644/121659767-33c00880-cad5-11eb-8b93-5b5773ac6d33.PNG)

+ This request also modified the error #413 
  - This is because of the devel environment of Bioconductor.
  - if the length of multiple logical vector > 2, and they combine with &&, 
     it will generate error. 

   ```
   > c(TRUE, TRUE) && c(TRUE, TRUE)
       ----------- FAILURE REPORT --------------
       --- failure: length > 1 in coercion to logical ---
       --- srcref ---
       :
       --- package (from environment) ---
       package:stats
      --- call from context ---
      NULL
      --- call from argument ---
     c(TRUE, TRUE) && c(TRUE, TRUE)
     --- R stacktrace ---

     --- value of length: 2 type: logical ---
     [1] TRUE TRUE
     --- function from context ---
     --- function search by body ---
     ----------- END OF FAILURE REPORT --------------
     Error in c(TRUE, TRUE) && c(TRUE, TRUE) :
       'length(x) = 2 > 1' in coercion to 'logical(1)'
   ```