### PR TITLE
adjust y for slanted layout

### DIFF
--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -194,7 +194,7 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
     list(
         if (show_segment){
             lineparams <- list(mapping = segment_mapping, linetype=linetype, nudge_x = offset, size = linesize, stat = StatTreeData)
-            lineparams <- extract_params(lineparams, params, c("colour", "alpha", "show.legend", "na.rm",
+            lineparams <- extract_params(lineparams, params, c("data", "colour", "alpha", "show.legend", "na.rm",
                                                                "inherit.aes", "arrow", "arrow.fill", "lineend")) 
             do.call("geom_segment2", lineparams)
         }

--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -182,19 +182,19 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
             segment_mapping <- modifyList(segment_mapping, mapping)
     }
     imageparams <- list(mapping=text_mapping, hjust = hjust, nudge_x = offset, stat = StatTreeData)
-    imageparams <- extract_params(imageparams, params, c("size", "alpha", "color", "colour", "image", 
+    imageparams <- extract_params(imageparams, params, c("data", "size", "alpha", "color", "colour", "image", 
                                                          "angle", "position", "inherit.aes", "by", "show.legend",
                                                          "image_fun", ".fun", "asp", "nudge_y", "height", "na.rm")) 
     labelparams <- list(mapping=text_mapping, hjust = hjust, nudge_x = offset, stat = StatTreeData)
     labelparams <- extract_params(labelparams, params, 
-                                  c("size", "alpha", "vjust", "color", "colour", "angle", "alpha", "family", "fontface",
+                                  c("data", "size", "alpha", "vjust", "color", "colour", "angle", "alpha", "family", "fontface",
                                     "lineheight", "fill", "position", "nudge_y", "show.legend", "check_overlap",
                                     "parse", "inherit.aes", "na.rm", "label.r", "label.size", "label.padding",
                                     "bg.colour", "bg.r"))
     list(
         if (show_segment){
             lineparams <- list(mapping = segment_mapping, linetype=linetype, nudge_x = offset, size = linesize, stat = StatTreeData)
-            lineparams <- extract_params(lineparams, params, c("colour", "alpha", "show.legend",  "na.rm",
+            lineparams <- extract_params(lineparams, params, c("colour", "alpha", "show.legend", "na.rm",
                                                                "inherit.aes", "arrow", "arrow.fill", "lineend")) 
             do.call("geom_segment2", lineparams)
         }

--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -10,6 +10,8 @@
 ##' @param continuous character, continuous transition for selected aesthethic ('size' 
 ##' or 'color'('colour')). It should be one of 'color' (or 'colour'), 'size', 'all' 
 ##' and 'none', default is 'none'
+##' @param position Position adjustment, either as a string, or the result of a
+##' call to a position adjustment function, default is "identity".
 ##' @param ... additional parameter
 ##'
 ##' some dot arguments:
@@ -28,7 +30,7 @@
 ##' @importFrom ggplot2 aes
 ##' @export
 ##' @author Yu Guangchuang
-geom_tree <- function(mapping=NULL, data=NULL, layout="rectangular", multiPhylo=FALSE, continuous="none", ...) {
+geom_tree <- function(mapping=NULL, data=NULL, layout="rectangular", multiPhylo=FALSE, continuous="none", position="identity", ...) {
     if (is.logical(continuous)){
         warning_wrap('The type of "continuous" argument was changed (v>=2.5.2). Now, 
                      it should be one of "color" (or "colour"), "size", "all", and "none".')
@@ -41,7 +43,7 @@ geom_tree <- function(mapping=NULL, data=NULL, layout="rectangular", multiPhylo=
         continuous <- ifelse(continuous, "color", "none")
     }
     continuous <- match.arg(continuous, c("color", "colour", "size", "none", "all"))
-    stat_tree(data=data, mapping=mapping, geom="segment",
+    stat_tree(data=data, mapping=mapping, geom="segment", position=position,
               layout=layout, multiPhylo=multiPhylo, continuous=continuous, ...)
 }
 

--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -56,7 +56,8 @@ fortify.phylo <- function(model, data,
     }
 
     if (layout == "slanted") {
-        res <- add_angle_slanted(res)
+        res <- add_angle_slanted(res) %>%
+               adjust.y.slanted(branch.length=branch.length)
     } else {
         ## angle for all layout, if 'rectangular', user use coord_polar, can still use angle
         res <- calculate_angle(res)

--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -56,8 +56,8 @@ fortify.phylo <- function(model, data,
     }
 
     if (layout == "slanted") {
-        res <- add_angle_slanted(res) %>%
-               adjust.y.slanted(branch.length=branch.length)
+        res %<>% adjust.y.slanted(branch.length=branch.length) %>%
+                 add_angle_slanted()
     } else {
         ## angle for all layout, if 'rectangular', user use coord_polar, can still use angle
         res <- calculate_angle(res)

--- a/R/tree-utilities.R
+++ b/R/tree-utilities.R
@@ -1247,8 +1247,8 @@ adjust.y.slanted <- function(x, branch.length){
     while(length(NextNode)>0){
         x <- cal.new.y.child(tbl=x, NextNode=NextNode)
         NextNode <- x %>%
-                       dplyr::filter(.data$parent %in% NextNode & !.data$isTip) %>%
-                       dplyr::pull(.data$node)
+                      dplyr::filter(.data$parent %in% NextNode & !.data$isTip) %>%
+                      dplyr::pull(.data$node)
     }
     return(x)
 }
@@ -1258,7 +1258,7 @@ cal.new.y.root <- function(tbl, root){
     dat <- tbl %>%
         dplyr::filter(.data$parent==root & .data$node!=root) %>%
         dplyr::arrange(.data$y)
-    x <- dat %>% dplyr::pull(.data$branch.length)
+    x <- dat %>% dplyr::pull(.data$x)
     y <- dat %>% dplyr::pull(.data$y)
     if (nrow(dat)==2){
         tbl[as.vector(tbl$node)==root, "y"] <- sum(x*rev(y))/sum(x)
@@ -1269,22 +1269,35 @@ cal.new.y.root <- function(tbl, root){
 # adjust y for slanted layout
 cal.new.y.child <- function(tbl, NextNode){
     for (i in NextNode){
-        yn <- tbl %>%
-                dplyr::filter(.data$node==i) %>%
-                dplyr::pull(.data$y)
-        
-        dat <- tbl %>%
-                dplyr::filter(.data$parent==i) %>%
-                dplyr::arrange(.data$y)
+        parent.node <- tbl %>% 
+                  dplyr::filter(.data$node==i) %>%
+                  dplyr::pull(.data$parent)
+        parent.da <- tbl %>% 
+                    dplyr::filter(.data$node==parent.node)
 
-        if (nrow(dat) == 2){
-            x <- dat %>% dplyr::pull(.data$branch.length)
+        parent.x <- parent.da %>%
+                    dplyr::pull(.data$x)
+        parent.y <- parent.da %>%
+                    dplyr::pull(.data$y)
+
+        node.da <- tbl %>%
+                   dplyr::filter(.data$node==i)
+                
+        xn <- node.da %>% 
+              dplyr::pull(.data$x)
+        yn <- node.da %>% 
+              dplyr::pull(.data$y)
+
+        dat <- tbl %>%
+               dplyr::filter(.data$parent==i) 
+
+        if (nrow(dat) > 1){
+            x <- abs(dat %>% dplyr::pull(.data$x) - xn)
             y <- dat %>% dplyr::pull(.data$y)
-            y <-  y - (sum(y)/2 - yn)
-            y1 <- (sum(x*yn) + x[[1]]*(y[[1]]-y[[2]]))/sum(x)
-            y2 <- (sum(x*yn) + x[[2]]*(y[[2]]-y[[1]]))/sum(x)
-            tbl[as.vector(tbl$node)==dat$node[[1]], "y"] <- y1
-            tbl[as.vector(tbl$node)==dat$node[[2]], "y"] <- y2
+            y <-  y - (sum(y)/length(y) - yn)
+            signflag <- ifelse(y>yn, -1, 1)
+            y <- yn - (x * abs(yn - parent.y))/(signflag*abs(xn-parent.x))
+            tbl[match(dat$node, tbl$node), "y"] <- y
         }else if (nrow(dat) == 1){
             tbl[as.vector(tbl$node)==dat$node, "y"] <- yn
         }

--- a/man/geom_tree.Rd
+++ b/man/geom_tree.Rd
@@ -10,6 +10,7 @@ geom_tree(
   layout = "rectangular",
   multiPhylo = FALSE,
   continuous = "none",
+  position = "identity",
   ...
 )
 }
@@ -26,6 +27,9 @@ geom_tree(
 \item{continuous}{character, continuous transition for selected aesthethic ('size'
 or 'color'('colour')). It should be one of 'color' (or 'colour'), 'size', 'all'
 and 'none', default is 'none'}
+
+\item{position}{Position adjustment, either as a string, or the result of a
+call to a position adjustment function, default is "identity".}
 
 \item{...}{additional parameter
 


### PR DESCRIPTION
+ adjust y for the `slanted` layout to keep the same scale zoom with the `branch.length`

```
> library(ggtree)
ggtree v3.1.2.991  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics, 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> set.seed(123)
> tr <- rtree(18)
> tr %>% ggtree(layout="slanted", color="red") + geom_tree()
> tr %>% ggtree(layout="slanted", color="red") + geom_tree() -> p1
> tr %>% ggtree() + geom_tree(layout="slanted", color="blue") -> p2
> p1/p2
> tr %>% ggtree(layout="slanted", color="red", branch.length="none") + geom_tree() -> f1
> tr %>% ggtree(branch.length="none") + geom_tree(layout="slanted", color="blue") -> f2
> f1/f2
```
![test2](https://user-images.githubusercontent.com/17870644/127463794-ce83f014-c112-4e66-8932-787df576ba78.PNG)
![test3](https://user-images.githubusercontent.com/17870644/127463799-ac2019f4-515d-46fe-b87a-1f563bfaf83e.PNG)
