### PR TITLE
fix the issue of data argument of geom_tiplab

### DIFF
--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -182,19 +182,19 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
             segment_mapping <- modifyList(segment_mapping, mapping)
     }
     imageparams <- list(mapping=text_mapping, hjust = hjust, nudge_x = offset, stat = StatTreeData)
-    imageparams <- extract_params(imageparams, params, c("size", "alpha", "color", "colour", "image", 
+    imageparams <- extract_params(imageparams, params, c("data", "size", "alpha", "color", "colour", "image", 
                                                          "angle", "position", "inherit.aes", "by", "show.legend",
                                                          "image_fun", ".fun", "asp", "nudge_y", "height", "na.rm")) 
     labelparams <- list(mapping=text_mapping, hjust = hjust, nudge_x = offset, stat = StatTreeData)
     labelparams <- extract_params(labelparams, params, 
-                                  c("size", "alpha", "vjust", "color", "colour", "angle", "alpha", "family", "fontface",
+                                  c("data", "size", "alpha", "vjust", "color", "colour", "angle", "alpha", "family", "fontface",
                                     "lineheight", "fill", "position", "nudge_y", "show.legend", "check_overlap",
                                     "parse", "inherit.aes", "na.rm", "label.r", "label.size", "label.padding",
                                     "bg.colour", "bg.r"))
     list(
         if (show_segment){
             lineparams <- list(mapping = segment_mapping, linetype=linetype, nudge_x = offset, size = linesize, stat = StatTreeData)
-            lineparams <- extract_params(lineparams, params, c("colour", "alpha", "show.legend",  "na.rm",
+            lineparams <- extract_params(lineparams, params, c("data", "colour", "alpha", "show.legend", "na.rm",
                                                                "inherit.aes", "arrow", "arrow.fill", "lineend")) 
             do.call("geom_segment2", lineparams)
         }

--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -10,6 +10,8 @@
 ##' @param continuous character, continuous transition for selected aesthethic ('size' 
 ##' or 'color'('colour')). It should be one of 'color' (or 'colour'), 'size', 'all' 
 ##' and 'none', default is 'none'
+##' @param position Position adjustment, either as a string, or the result of a
+##' call to a position adjustment function, default is "identity".
 ##' @param ... additional parameter
 ##'
 ##' some dot arguments:
@@ -28,7 +30,7 @@
 ##' @importFrom ggplot2 aes
 ##' @export
 ##' @author Yu Guangchuang
-geom_tree <- function(mapping=NULL, data=NULL, layout="rectangular", multiPhylo=FALSE, continuous="none", ...) {
+geom_tree <- function(mapping=NULL, data=NULL, layout="rectangular", multiPhylo=FALSE, continuous="none", position="identity", ...) {
     if (is.logical(continuous)){
         warning_wrap('The type of "continuous" argument was changed (v>=2.5.2). Now, 
                      it should be one of "color" (or "colour"), "size", "all", and "none".')
@@ -41,7 +43,7 @@ geom_tree <- function(mapping=NULL, data=NULL, layout="rectangular", multiPhylo=
         continuous <- ifelse(continuous, "color", "none")
     }
     continuous <- match.arg(continuous, c("color", "colour", "size", "none", "all"))
-    stat_tree(data=data, mapping=mapping, geom="segment",
+    stat_tree(data=data, mapping=mapping, geom="segment", position=position,
               layout=layout, multiPhylo=multiPhylo, continuous=continuous, ...)
 }
 

--- a/man/geom_tree.Rd
+++ b/man/geom_tree.Rd
@@ -10,6 +10,7 @@ geom_tree(
   layout = "rectangular",
   multiPhylo = FALSE,
   continuous = "none",
+  position = "identity",
   ...
 )
 }
@@ -26,6 +27,9 @@ geom_tree(
 \item{continuous}{character, continuous transition for selected aesthethic ('size'
 or 'color'('colour')). It should be one of 'color' (or 'colour'), 'size', 'all'
 and 'none', default is 'none'}
+
+\item{position}{Position adjustment, either as a string, or the result of a
+call to a position adjustment function, default is "identity".}
 
 \item{...}{additional parameter
 


### PR DESCRIPTION
+ fix data argument of `geom_tiplab`
   #423 
+ export `position` argument of `geom_tree`, so the 
   geom_tree layer can also be panned via `position_nudge` of `ggplot2`
   or `position_identityx()` of `ggtreeExtra`.

```
> library(ggtree)
> library(ggplot2)
> set.seed(123)
> tr <- rtree(20)
> da1 <- fortify(tr)
> da2 <- da1
> p <- ggtree(da1)
> p + geom_tree(data=da2, position=position_nudge(x=max(da1$x)+0.5), layout="roundrect")
```
![f1](https://user-images.githubusercontent.com/17870644/128828163-9a3fbdb7-bbc1-464c-80df-4d8b55a8078b.PNG)
