### PR TITLE
options to control the line type of radial

### DIFF
--- a/R/geom_tree.R
+++ b/R/geom_tree.R
@@ -104,10 +104,12 @@ stat_tree <- function(mapping=NULL, data=NULL, geom="segment", position="identit
                    )
              )
     } else if (layout %in% c("slanted", "radial", "equal_angle", "daylight", "ape")) {
+        line.type <- getOption(x="radial.line.type", default="straight")
+        geom <- switch(line.type, straight=GeomSegmentGGtree, curved=geom)
         layer(stat=StatTree,
               data=data,
               mapping=mapping,
-              geom = GeomSegmentGGtree,
+              geom = geom,
               position=position,
               show.legend = show.legend,
               inherit.aes = inherit.aes,


### PR DESCRIPTION
I think the curved line of radial layout sometimes is better.

I add an `options` to control the line type of radial layout.

And the default is `straight`.  But It will convert to `curved` when
 `MicrobiotaProcess` was loaded.

```
> library(ggtree)
ggtree v3.1.3  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics, 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> library(MicrobiotaProcess)
> example(mp_import_metaphlan)

mp_mp_> file1 <- system.file("extdata/MetaPhlAn", "metaphlan_test.txt", package="MicrobiotaProcess")

mp_mp_> sample.file <- system.file("extdata/MetaPhlAn", "sample_test.txt", package="MicrobiotaProcess")

mp_mp_> readLines(file1, n=3) %>% writeLines()
species taxid   GupDM_JP        GupDM_JG        GupDM_A4        GupDM_JM        GupDM_A13       GupDM_JK        GupDM_JI        GupDM_A7        GupDM_A2        GupDM_A_11      GupDM_JC        GupDM_JN        GupDM_JJ   GupDM_JO        GupDM_A1        GupDM_JE        GupDM_A12       GupDM_JL        GupDM_A14       GupDM_A8
k__Archaea      2157    0.59617 0.91338 0       0.28251 0       0.06709 0.34405 0       19.73944        0       0.5279  0.29173 0.71767 0.21462 0       0.17853 0       7.25853 0       0
k__Archaea|p__Euryarchaeota     2157|28890      0.59617 0.91338 0       0.28251 0       0.06709 0.34405 0       19.73944        0       0.5279  0.29173 0.71767 0.21462 0       0.17853 0       7.25853 0       0

mp_mp_> mpse1 <- mp_import_metaphlan(profile=file1, mapfilename=sample.file)

mp_mp_> mpse1
# A MPSE-tibble (MPSE object) abstraction: 5,260 x 11
# OTU=263 | Samples=20 | Assays=Abundance | Taxanomy=Kingdom, Phylum, Class, Order, Family, Genus
   OTU    Sample  Abundance group taxid  Kingdom Phylum Class Order Family Genus
   <chr>  <chr>       <dbl> <chr> <chr>  <chr>   <chr>  <chr> <chr> <chr>  <chr>
 1 s__Me… GupDM_…     0.596 testA 2157|… k__Arc… p__Eu… c__M… o__M… f__Me… g__M…
 2 s__Me… GupDM_…     0.913 testA 2157|… k__Arc… p__Eu… c__M… o__M… f__Me… g__M…
 3 s__Ac… GupDM_…     0     testA 2|201… k__Bac… p__Ac… c__A… o__A… f__Ac… g__A…
 4 s__Ac… GupDM_…     0     testA 2|201… k__Bac… p__Ac… c__A… o__A… f__Ac… g__A…
 5 s__Ac… GupDM_…     0     testA 2|201… k__Bac… p__Ac… c__A… o__A… f__Ac… g__A…
 6 s__Ac… GupDM_…     0     testA 2|201… k__Bac… p__Ac… c__A… o__A… f__Ac… g__A…
 7 s__Ac… GupDM_…     0     testA 2|201… k__Bac… p__Ac… c__A… o__A… f__Ac… g__A…
 8 s__Ac… GupDM_…     0     testA 2|201… k__Bac… p__Ac… c__A… o__A… f__Ac… g__A…
 9 s__Bi… GupDM_…     0.948 testA 2|201… k__Bac… p__Ac… c__A… o__B… f__Bi… g__B…
10 s__Bi… GupDM_…     1.77  testA 2|201… k__Bac… p__Ac… c__A… o__B… f__Bi… g__B…
# … with 5,250 more rows
Warning message:
The number of features in otu table is not equal the number of features in taxonomy annotation.
* The same features will be extract automatically !
> mpse1 %>% mp_extract_tree() %>% ggtree(layout="radial")
```
![curved radial](https://user-images.githubusercontent.com/17870644/129367650-17ba04ac-84ac-4100-b5a8-907a41319af9.PNG)

```
> options(radial.line.type="straight")
> mpse1 %>% mp_extract_tree() %>% ggtree(layout="radial")
```
![xx](https://user-images.githubusercontent.com/17870644/129367667-faba5136-0dbb-4c0b-a54d-699e3cbe4b72.PNG)

