### PR TITLE
introduce align argument in geom_hilight

### DIFF
--- a/man/geom-hilight.Rd
+++ b/man/geom-hilight.Rd
@@ -46,6 +46,9 @@ aesthetics are in bold):
 \item \code{extendto} specify a value, meaning the rectangle extend to, default is NULL.
 \item \code{linetype} the line type of margin, default is 1.
 \item \code{size} the width of line of margin, default is 0.5.
+\item \code{align} control the align direction of the edge of high light rectangular.
+Options is 'none' (default), 'left', 'right', 'both'. This argument only work when the
+'geom_hilight' is plotting using geom_hilight(mapping=aes(...)).
 }
 \code{geom_hilight()} understands the following aesthethics for encircle layer (required
 aesthetics are in bold):
@@ -73,6 +76,10 @@ p1
 dat <- data.frame(id=c(62, 88), type=c("A", "B"))
 p2 <- p + geom_hilight(data=dat, mapping=aes(node=id, fill=type))
 p2
+p3 <- p + geom_hilight(data=dat, mapping=aes(node=id, fill=type), align="left")
+p4 <- p + geom_hilight(data=dat, mapping=aes(node=id, fill=type), align="right")
+p5 <- p + geom_hilight(data=dat, mapping=aes(node=id, fill=type), align="both")
+p2/ p3/ p4/ p5
 }
 \author{
 Guangchuang Yu and Shuangbin Xu


### PR DESCRIPTION
introduce `align` argument to control the align direction of `geom_hilight`

```
> library(ggtree)
ggtree v3.1.3.992  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics, 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> set.seed(102)
> tree <- rtree(60)
> p <- ggtree(tree)
> dat <- data.frame(id=c(62, 88), type=c("A", "B"))
> p1 <- p + geom_hilight(data=dat, mapping=aes(node=id, fill=type))
> p2 <- p + geom_hilight(data=dat, mapping=aes(node=id, fill=type), align="left")
> p3 <- p + geom_hilight(data=dat, mapping=aes(node=id, fill=type), align="right")
> p4 <- p + geom_hilight(data=dat, mapping=aes(node=id, fill=type), align="both")
> p5 <- p + geom_hilight(data=dat, mapping=aes(node=id, fill=type), align="both", extendto=10)
> p1/p2/p3/p4/p5
```
![test](https://user-images.githubusercontent.com/17870644/131298912-517186bc-f46c-445d-b4e1-15736f01a509.PNG)
