### PR TITLE
Nudge x geom segment2

### DIFF
--- a/R/geom_segment.R
+++ b/R/geom_segment.R
@@ -89,6 +89,9 @@ GeomSegmentGGtree <- ggproto("GeomSegmentGGtree", GeomSegment,
 
                              draw_panel = function(data, panel_params, coord, arrow = NULL, arrow.fill = NULL,
                                                    lineend = "butt", linejoin = "round", na.rm = FALSE, nudge_x = 0) {
+
+                                 data$x <- data$x + nudge_x
+
                                  data <- ggplot2::remove_missing(data, na.rm = na.rm, c("x", "y", "xend",
                                                         "yend", "linetype", "size", "shape"), name = "geom_segment")
                                  if (empty(data))
@@ -110,7 +113,6 @@ GeomSegmentGGtree <- ggproto("GeomSegmentGGtree", GeomSegment,
                                  }else{
                                      data <- coord$transform(data, panel_params)
                                  }
-                                 data$x <- data$x + nudge_x
 
                                  arrow.fill <- arrow.fill %||% data$colour
                                  return(grid::segmentsGrob(data$x, data$y, data$xend, data$yend,


### PR DESCRIPTION
fix the issue of `nudge_x` parameter of `geom_segment2`

![xx](https://user-images.githubusercontent.com/17870644/131969242-b87f28e2-8ba7-4210-bc21-5d2aea6488fb.PNG)

it should be added before the transform of `coord`.
![xx2](https://user-images.githubusercontent.com/17870644/131970434-096ee8dd-0f0a-4469-8275-46831a739583.PNG)




