### PR TITLE
custom column headers for gheatmap

### DIFF
--- a/R/gheatmap.R
+++ b/R/gheatmap.R
@@ -19,6 +19,7 @@
 ##' @param family font of matrix colnames
 ##' @param hjust hjust for column names (0: align left, 0.5: align center, 1: align righ)
 ##' @param legend_title title of fill legend
+##' @param column_annotation in place of the colnames from a matrix, input a custom vector of column labels
 ##' @return tree view
 ##' @importFrom ggplot2 geom_tile
 ##' @importFrom ggplot2 geom_text
@@ -35,7 +36,8 @@
 ##' @author Guangchuang Yu
 gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color="white",
                      colnames=TRUE, colnames_position="bottom", colnames_angle=0, colnames_level=NULL,
-                     colnames_offset_x = 0, colnames_offset_y = 0, font.size=4, family="", hjust=0.5, legend_title = "value") {
+                     colnames_offset_x = 0, colnames_offset_y = 0, font.size=4, family="", hjust=0.5, legend_title = "value",
+                     column_annotation = NULL) {
 
     colnames_position %<>% match.arg(c("bottom", "top"))
     variable <- value <- lab <- y <- NULL
@@ -121,8 +123,25 @@ gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color=
         }
         mapping$y <- y
         mapping[[".panel"]] <- factor("Tree")
-        p2 <- p2 + geom_text(data=mapping, aes(x=to, y = y, label=from), size=font.size, family=family, inherit.aes = FALSE,
-                             angle=colnames_angle, nudge_x=colnames_offset_x, nudge_y = colnames_offset_y, hjust=hjust)
+        # if custom column annotations are provided
+        if (!is.null(column_annotation)) {
+            # assess the type of input for the custom column annotation
+            # either a vector or a named vector with positions for specific names
+            if (!is.null(names(column_annotation))) {
+                vector_to_fill <- rep("", nrow(mapping))
+                for (name in names(column_annotation)) {
+                    vector_to_fill[unname(column_annotation[name])] = name
+                }
+                mapping$custom_labels <- vector_to_fill
+            } else {
+                mapping$custom_labels <- column_annotation
+            }
+            p2 <- p2 + geom_text(data=mapping, aes(x=to, y = y, label=custom_labels), size=font.size, family=family, inherit.aes = FALSE,
+                                angle=colnames_angle, nudge_x=colnames_offset_x, nudge_y = colnames_offset_y, hjust=hjust)
+        } else {
+            p2 <- p2 + geom_text(data=mapping, aes(x=to, y = y, label=from), size=font.size, family=family, inherit.aes = FALSE,
+                                 angle=colnames_angle, nudge_x=colnames_offset_x, nudge_y = colnames_offset_y, hjust=hjust)
+        }
     }
 
     p2 <- p2 + theme(legend.position="right")

--- a/R/gheatmap.R
+++ b/R/gheatmap.R
@@ -129,13 +129,13 @@ gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color=
             # either a vector or a named vector with positions for specific names
             if (is.null(names(custom_column_labels))) {
                 if (length(custom_column_labels) > nrow(mapping)) {
-                    warning("Input label vector has more elements than there are columns")
-                    sprintf("Using the first %s elements as labels", nrow(mapping))
-                    custom_column_labels <- custom_column_labels[1:nrow(mapping)]
-                    mapping$custom_labels <- custom_column_labels
-                 } else if (length(custom_column_labels) < nrow(mapping)){
-                        warning("Input label vector has fewer elements than there are columns")
-                        sprintf("Using all available labels, n = %s", length(custom_column_labels))
+                    warning(paste("Input column label vector has more elements than there are columns.",
+                                  "\n", "Using the first ", nrow(mapping)," elements as labels", sep=""))
+                    mapping$custom_labels <- custom_column_labels[1:nrow(mapping)]
+                 } else if (length(custom_column_labels) < nrow(mapping)) {
+                        warning(paste("Input column label vector has fewer elements than there are columns.",
+                                   "\n", "Using all available labels, n = ",
+                                   length(custom_column_labels), sep=""))
                      mapping$custom_labels <- c(custom_column_labels, rep("", nrow(mapping) - length(custom_column_labels)))
                  } else {
                         mapping$custom_labels <- custom_column_labels
@@ -143,14 +143,17 @@ gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color=
                 } else {
                 vector_to_fill <- rep("", nrow(mapping))
                 for (name in names(custom_column_labels)) {
-                    if (!as.numeric(unname(custom_column_labels[name]))) {
-                        warning("At least one element of the named column label vector was not a valid index")
-                        break
-                    } else if (as.numeric(unname(custom_column_labels[name])) > nrow(mapping)) {
-                        warning("Named column label vector tries to access an index that is out of range")
+                    # check to see if the index passed is valid integer
+                    if (!is.na(as.numeric(unname(custom_column_labels[name]))) &
+                        as.numeric(unname(custom_column_labels[name])) <= nrow(mapping)) {
+                        vector_to_fill[unname(custom_column_labels[name])] = name
+                    } else if (!is.na(as.numeric(unname(custom_column_labels[name]))) &
+                               as.numeric(unname(custom_column_labels[name])) > nrow(mapping)) {
+                        warning("Named column label vector tries to access an index that is out of range, so it will be discarded")
                         break
                     } else {
-                        vector_to_fill[unname(custom_column_labels[name])] = name
+                        warning("At least one element of the named column label vector was not a valid index")
+                        break
                     }
                 }
                 mapping$custom_labels <- vector_to_fill
@@ -158,7 +161,7 @@ gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color=
             p2 <- p2 + geom_text(data=mapping, aes(x=to, y = y, label=custom_labels), size=font.size, family=family, inherit.aes = FALSE,
                                  angle=colnames_angle, nudge_x=colnames_offset_x, nudge_y = colnames_offset_y, hjust=hjust)
         } else {
-            p2 <- p2 + geom_text(data=mapping, aes(x=to, y = y, label=cus), size=font.size, family=family, inherit.aes = FALSE,
+            p2 <- p2 + geom_text(data=mapping, aes(x=to, y = y, label=from), size=font.size, family=family, inherit.aes = FALSE,
                                  angle=colnames_angle, nudge_x=colnames_offset_x, nudge_y = colnames_offset_y, hjust=hjust)
         }
     }

--- a/R/gheatmap.R
+++ b/R/gheatmap.R
@@ -131,33 +131,30 @@ gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color=
                 if (length(custom_column_labels) > nrow(mapping)) {
                     warning(paste("Input column label vector has more elements than there are columns.",
                                   "\n", "Using the first ", nrow(mapping)," elements as labels", sep=""))
-                    mapping$custom_labels <- custom_column_labels[1:nrow(mapping)]
+                    mapping$custom_labels <- as.character(custom_column_labels[1:nrow(mapping)])
                  } else if (length(custom_column_labels) < nrow(mapping)) {
                         warning(paste("Input column label vector has fewer elements than there are columns.",
                                    "\n", "Using all available labels, n = ",
                                    length(custom_column_labels), sep=""))
-                     mapping$custom_labels <- c(custom_column_labels, rep("", nrow(mapping) - length(custom_column_labels)))
+                     mapping$custom_labels <- as.character(c(custom_column_labels,
+                                rep("", nrow(mapping) - length(custom_column_labels))))
                  } else {
                         mapping$custom_labels <- custom_column_labels
                     }
+            } else {
+                if (!is.null(colnames_level)) {
+                    # use the colnames levels if available
+                    # otherwise use the default order provided by the data frame
+                    vector_order <- colnames_level
+                    
                 } else {
-                vector_to_fill <- rep("", nrow(mapping))
-                for (name in names(custom_column_labels)) {
-                    # check to see if the index passed is valid integer
-                    if (!is.na(as.numeric(unname(custom_column_labels[name]))) &
-                        as.numeric(unname(custom_column_labels[name])) <= nrow(mapping)) {
-                        vector_to_fill[unname(custom_column_labels[name])] = name
-                    } else if (!is.na(as.numeric(unname(custom_column_labels[name]))) &
-                               as.numeric(unname(custom_column_labels[name])) > nrow(mapping)) {
-                        warning("Named column label vector tries to access an index that is out of range, so it will be discarded")
-                        break
-                    } else {
-                        warning("At least one element of the named column label vector was not a valid index")
-                        break
-                    }
+                    vector_order <- as.character(mapping$from)
                 }
-                mapping$custom_labels <- vector_to_fill
-            }
+                for (elem in custom_column_labels) {
+                    vector_order[which(vector_order == elem)] = names(which(custom_column_labels == elem))
+                }
+                mapping$custom_labels <- vector_order
+                }
             p2 <- p2 + geom_text(data=mapping, aes(x=to, y = y, label=custom_labels), size=font.size, family=family, inherit.aes = FALSE,
                                  angle=colnames_angle, nudge_x=colnames_offset_x, nudge_y = colnames_offset_y, hjust=hjust)
         } else {
@@ -165,7 +162,6 @@ gheatmap <- function(p, data, offset=0, width=1, low="green", high="red", color=
                                  angle=colnames_angle, nudge_x=colnames_offset_x, nudge_y = colnames_offset_y, hjust=hjust)
         }
     }
-
     p2 <- p2 + theme(legend.position="right")
     ## p2 <- p2 + guides(fill = guide_legend(override.aes = list(colour = NULL)))
 


### PR DESCRIPTION
When using the gheatmap with a phylogenetic tree, it can be useful to be able to add custom labels for the column headers, such as nucleotide positions or information about a SNP. This PR adds the ability for the user to input a label vector as an argument in gheatmap named custom_column_labels. 

It is able to handle different vector inputs. For example, if passing an unnamed vector such as the following for a heatmap with 10 columns: 

`labels_7 <- as.character(seq(1, 7, 1))`

It will add these 7 labels to the heat map starting at column 1, and fill in the remaining 3 columns as blanks. 

![custom_labels_vector_short](https://user-images.githubusercontent.com/40243147/133105647-43f6af31-13ae-4df4-8a52-8868bb4f7599.png)

If instead of 7 elements, 10 are added, then all 10 column headers would get a label.

Additionally, the user could also add a named vector, where the name of an element is the label and the vector value is the index where the label goes. For example, passing the following to the same 10-column heat map: 

`named_labels <- c("defining" = 1, "conserved" = 10)`

Can result in the following: 

![custom_labels_named_vector](https://user-images.githubusercontent.com/40243147/133105835-d8ad3a47-5abc-4c81-a776-8df6c7ce6be8.png)

**Handling errors and exceptions**

The code also handles error cases. If the vector passed has more elements than there are columns, it will take only the first n column labels with a warning. 

If using a named vector, and an index out of range is passed, it will be discarded with a warning. If there are still 10 columns,
this:
`named_labels <- c("defining" = 1, "conserved" = 12)`

results in: 
`Named column label vector tries to access an index that is out of range, so it will be discarded`

and only one valid label is added:

![custom_labels_named_vector_out_range](https://user-images.githubusercontent.com/40243147/133107107-c359d13a-bad5-4e6b-bab1-041baf7340b0.png)


Lastly, if the named vector is in the incorrect format, a warning will be thrown. For example, this following vector: 

`named_labels <- c("defining" = 1, "conserved" = "last_pos")`

does not provide a proper column index for "conserved". So the warning is as follows: 

`At least one element of the named column label vector was not a valid index`


