### PR TITLE
ggdensitree with align.tips=TRUE sets max x to 0

### DIFF
--- a/R/ggdensitree.R
+++ b/R/ggdensitree.R
@@ -119,11 +119,10 @@ ggdensitree <- function(data=NULL, mapping=NULL, layout="slanted", tip.order='mo
 	
 	## reorder tips (and shift x id align tips)
 	max.x <- vapply(trees.f, function(x) max(x$x, na.rm = TRUE), numeric(1))
-	farthest <- max(max.x)
 	trees.f <- lapply(1:length(trees), function(i) {
 		trees.f[[i]]$y <- getYcoord(trees[[i]], tip.order = tip.order)
 		if (align.tips) {
-			trees.f[[i]]$x <- trees.f[[i]]$x + (farthest - max.x[i])
+			trees.f[[i]]$x <- trees.f[[i]]$x - max.x[i]
 		}
 		if (i > 1 && jitter > 0) {
 			trees.f[[i]]$y[1:n.tips] %<>% add(stats::rnorm(n.tips, mean=0, sd=jitter))


### PR DESCRIPTION
Hi Dr. Yu,

In response to #437, I thought that it might be better for `ggdensitree` to set the maximum x value to 0 when you align tips instead of the default value which is the height of the tallest tree. With this change

```R
ggdensitree(trees) + theme_tree2()
```

would appear as if you ran `revts` on the plot. I think this works better because many of times that people will want to use `ggdensitree`, they will want to indicate time in the past. And if they want to indicate calendar dates it is easier to work from the tip dates than from a root which may have an arbitrary date.

As an aside, I think that the `revts` function might need to be reworked, since it doesn't really follow the `ggplot` philosophy. Maybe you could turn it into a scale?