### PR TITLE
fix the issue of negative edge.length

### DIFF
--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -386,7 +386,7 @@ ggplot_add.cladelab <- function(object, plot, object_name){
                                        params=object$params)
     bar_obj <- c(bar_obj, bar_dot_params)
     if (layout == "unrooted" || layout == "daylight"){
-        bar_obj <- do.call("geom_curve", bar_obj)
+        bar_obj <- do.call(ggplot2::geom_curve, bar_obj)
     }else{
         bar_obj <- do.call("geom_segment", bar_obj)
     }

--- a/R/tree-utilities.R
+++ b/R/tree-utilities.R
@@ -767,7 +767,7 @@ getXcoord2 <- function(x, root, parent, child, len, start=0, rev=FALSE) {
     while(anyNA(x)) {
         idx <- which(parent %in% currentNode)
         newNode <- child[idx]
-        x[newNode] <- x[parent[idx]]+len[idx] * direction
+        x[newNode] <- x[parent[idx]]+len[idx] * direction * sign(len[idx])
         currentNode <- newNode
     }
 


### PR DESCRIPTION
fix the issue of negative `edge.length`

```
library(ggtree)
set.seed(123)
tr <- rtree(10)
tr$edge.length[10] <- -1 * tr$edge.length[10]
p <- tr %>% ggtree()
p
```
![p](https://user-images.githubusercontent.com/17870644/135219371-3f3fc189-e075-4a35-b386-b332e9606997.PNG)

```
set.seed(123)
d <- matrix(rnorm(100), 10)
xx <- hclust(as.dist(d))
tr2 <- ape::as.phylo(xx)
p2 <- tr2 %>% ggtree(layout="dend")  + 
                         geom_tiplab(hjust=0.5, vjust=1) + 
                         theme_dendrogram()
library(ggplotify)
as.ggplot(~plot(xx)) + p2
```
![p2](https://user-images.githubusercontent.com/17870644/135219370-64d99e54-1f15-4d01-ac3b-716668b71903.PNG)
