### PR TITLE
fix the mapping of line of geom_tiplab when align=TRUE

### DIFF
--- a/R/geom_tiplab.R
+++ b/R/geom_tiplab.R
@@ -178,8 +178,8 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
                                node = node,
                                label = label,
                                subset = isTip)
-        if (!is.null(mapping))
-            segment_mapping <- modifyList(segment_mapping, mapping)
+        if (!is.null(text_mapping))
+            segment_mapping <- modifyList(segment_mapping, text_mapping)
     }
     imageparams <- list(mapping=text_mapping, hjust = hjust, nudge_x = offset, stat = StatTreeData)
     imageparams <- extract_params(imageparams, params, c("data", "size", "alpha", "color", "colour", "image", 
@@ -194,7 +194,7 @@ geom_tiplab_rectangular <- function(mapping=NULL, hjust = 0,  align = FALSE,
     list(
         if (show_segment){
             lineparams <- list(mapping = segment_mapping, linetype=linetype, nudge_x = offset, size = linesize, stat = StatTreeData)
-            lineparams <- extract_params(lineparams, params, c("data", "colour", "alpha", "show.legend", "na.rm",
+            lineparams <- extract_params(lineparams, params, c("data", "color", "colour", "alpha", "show.legend", "na.rm",
                                                                "inherit.aes", "arrow", "arrow.fill", "lineend")) 
             do.call("geom_segment2", lineparams)
         }


### PR DESCRIPTION

fix the mapping of line of geom_tiplab when align = TRUE

```
> library(ggtree)
ggtree v3.3.0.900  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics. 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution. 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution. 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> set.seed(124)
> tr <- rtree(10)
> ggtree(tr) + geom_tiplab() + geom_tiplab(mapping=aes(subset=label %in% c("t1", "t5")), offset=1, align=TRUE)
> ggtree(tr) + geom_tiplab() + geom_tiplab(data=td_filter(label %in% c("t1", "t5")), offset=1, align=TRUE)
```
![xx](https://user-images.githubusercontent.com/17870644/141471192-274b2dc9-9e62-42a5-acef-09a1f2fa93f7.PNG)
