### PR TITLE
Graph layout

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,7 +45,8 @@ Suggests:
     rmarkdown,
     stats,
     testthat,
-    tibble
+    tibble,
+    glue
 Remotes:
     GuangchuangYu/treeio
 VignetteBuilder: knitr

--- a/R/ggtree.R
+++ b/R/ggtree.R
@@ -101,6 +101,8 @@ ggtree <- function(tr,
                 ...)
 
     if (!is.null(dd)){
+        message_wrap("The tree object will be displayed with graph layout since 
+                      layout argument was specified the graph layout function.")
         p$data <- dplyr::left_join(
                     p$data %>% select(-c("x", "y")), 
                     dd, 

--- a/R/ggtree.R
+++ b/R/ggtree.R
@@ -16,6 +16,7 @@
 ##' @param branch.length variable for scaling branch, if 'none' draw cladogram
 ##' @param root.position position of the root node (default = 0)
 ##' @param xlim x limits, only works for 'inward_circular' layout
+##' @param layout.params list, the parameters of layout, when layout is a function.
 ##' @return tree
 ##' @importFrom ggplot2 ggplot
 ##' @importFrom ggplot2 xlab
@@ -53,12 +54,22 @@ ggtree <- function(tr,
                    branch.length  = "branch.length",
                    root.position  = 0,
                    xlim = NULL,
+                   layout.params = list(),
                    ...) {
 
     # Check if layout string is valid.
-    layout %<>% match.arg(c("rectangular", "slanted", "fan", "circular", 'inward_circular',
+    trash <- try(silent = TRUE,
+                 expr = {
+                   layout %<>% match.arg(c("rectangular", "slanted", "fan", "circular", 'inward_circular',
                             "radial", "unrooted", "equal_angle", "daylight", "dendrogram",
                             "ape", "ellipse", "roundrect"))
+                  }
+             )
+
+    dd <- check.graph.layout(tr, trash, layout, layout.params)
+    if (inherits(trash, "try-error") && !is.null(dd)){
+        layout <- "rectangular"
+    }
 
     if (layout == "unrooted") {
         layout <- "daylight"
@@ -88,6 +99,15 @@ ggtree <- function(tr,
                 branch.length = branch.length,
                 root.position = root.position,
                 ...)
+
+    if (!is.null(dd)){
+        p$data <- dplyr::left_join(
+                    p$data %>% select(-c("x", "y")), 
+                    dd, 
+                    by = "node"
+        )
+        layout <- "equal_angle"
+    }
 
     if (is(tr, "multiPhylo")) {
         multiPhylo <- TRUE
@@ -153,4 +173,31 @@ ggtree_references <- function() {
            "Data Integration, Manipulation and Visualization of Phylogenetic Trees.",
            "<http://yulab-smu.top/treedata-book/>\n"
            )
+}
+
+check.graph.layout <- function(tr, trash, layout, layout.params){
+    if (inherits(trash, "try-error")){
+        gp <- ape::as.igraph.phylo(as.phylo(tr), use.labels = FALSE)
+        #dd <- ggraph::create_layout(gp, layout = layout)
+        if (is.function(layout)){
+            dd <- do.call(layout, c(list(gp), layout.params))
+            if (!inherits(dd, "matrix")){
+                if ("xy" %in% names(dd)){
+                    dd <- dd$xx
+                }else if ("layout" %in% names(dd)){
+                    dd <- dd$layout
+                }else{
+                    stop(trash, call. = FALSE)
+                }
+            }
+            dd <- data.frame(dd)
+            colnames(dd) <- c("x", "y")
+            dd$node <- seq_len(nrow(dd))
+        }else{
+            stop(trash, call. = FALSE)
+        }
+    }else{
+        dd <- NULL
+    }
+    return(dd)
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -117,6 +117,17 @@ getCols <- function (n) {
     grDevices::colorRampPalette(col3)(n)
 }
 
+message_wrap <- function(...){
+    msg <- .return_wrap(...)
+    message(msg)
+}
+
+.return_wrap <- function(...){
+    msg <- paste(..., collapse = "", sep = "")
+    wrapped <- strwrap(msg, width = getOption("width") - 2) %>%
+        glue::glue_collapse(., "\n", last = "\n")
+    wrapped
+}
 
 ##
 ##

--- a/man/ggtree.Rd
+++ b/man/ggtree.Rd
@@ -21,6 +21,7 @@ ggtree(
   branch.length = "branch.length",
   root.position = 0,
   xlim = NULL,
+  layout.params = list(),
   ...
 )
 }
@@ -53,6 +54,8 @@ right-hand side? See \code{\link[ape:ladderize]{ape::ladderize()}} for more info
 \item{root.position}{position of the root node (default = 0)}
 
 \item{xlim}{x limits, only works for 'inward_circular' layout}
+
+\item{layout.params}{list, the parameters of layout, when layout is a function.}
 
 \item{...}{additional parameter
 


### PR DESCRIPTION
+ add graph layout
  - It is compatible with the feature of `ggtree`.
  - because the graph layout was used, the edge length of tree might is meaningless.


```
> library(ggtree)
ggtree v3.3.0.901  For help: https://yulab-smu.top/treedata-book/

If you use ggtree in published research, please cite the most appropriate paper(s):

1. Guangchuang Yu. Using ggtree to visualize data on tree-like structures. Current Protocols in Bioinformatics. 2020, 69:e96. doi:10.1002/cpbi.96
2. Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods for mapping and visualizing associated data on phylogeny using ggtree. Molecular Biology and Evolution. 2018, 35(12):3041-3043. doi:10.1093/molbev/msy194
3. Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam. ggtree: an R package for visualization and annotation of phylogenetic trees with their covariates and other associated data. Methods in Ecology and Evolution. 2017, 8(1):28-36. doi:10.1111/2041-210X.12628


> set.seed(123)
> tree <- rtree(30)
> ggtree(tree, layout=igraph::layout_with_kk) + geom_tiplab() + geom_nodelab(aes(label=node)) + geom_hilight(node=41, type="encircle", expand=0.05) -> p1
> ggtree(tree) + geom_tiplab() + geom_nodelab(aes(label=node)) + geom_hilight(node=41) -> p2
> p1 + p2
```
![xx](https://user-images.githubusercontent.com/17870644/145523729-b9a53fcb-7989-473d-8537-6a040c28a8bf.PNG)
