### PR TITLE
remove ggimage dependency for theme

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -119,12 +119,7 @@ theme_tree2_internal <- function(bgcolor="white", fgcolor="black",
 theme_inset <- function(legend.position =  "none", ...) {
     list(xlab(NULL),
          ylab(NULL),
-         theme_tree(legend.position = legend.position,
-                    function() theme(panel.background = element_rect(fill = "transparent", colour = NA),
-                                     plot.background = element_rect(fill = "transparent", colour = NA), 
-                                     legend.key = element_rect(fill = "transparent", colour = NA),
-                                     legend.background = element_rect(fill = "transparent",colour = NA),
-                                     ...)
-                    )
+         theme_tree(legend.position = legend.position, ...),
+         ggfun::theme_transparent()
          )
 }

--- a/R/theme.R
+++ b/R/theme.R
@@ -119,7 +119,12 @@ theme_tree2_internal <- function(bgcolor="white", fgcolor="black",
 theme_inset <- function(legend.position =  "none", ...) {
     list(xlab(NULL),
          ylab(NULL),
-         theme_tree(legend.position =  legend.position, ...),
-         ggimage::theme_transparent()
+         theme_tree(legend.position = legend.position,
+                    function() theme(panel.background = element_rect(fill = "transparent", colour = NA),
+                                     plot.background = element_rect(fill = "transparent", colour = NA), 
+                                     legend.key = element_rect(fill = "transparent", colour = NA),
+                                     legend.background = element_rect(fill = "transparent",colour = NA),
+                                     ...)
+                    )
          )
 }


### PR DESCRIPTION
I propose to loan a small snippet of code from the ggimage package into ggtree

This way, the user does not need to install the package ggimage (which also has other dependencies) when using this theme. I use the function `nodepie` to plot pie charts, which in turn depends on `ggpie()` and `theme_inset()`.

Hope it is okay
Bjørn Kopperud