### PR TITLE
introducing to.bottom in geom_hilight

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ Suggests:
     emojifont,
     ggimage,
     ggplotify,
+    shadowtext,
     grDevices,
     knitr,
     prettydoc,

--- a/R/geom_hilight.R
+++ b/R/geom_hilight.R
@@ -13,6 +13,8 @@
 #' unrooted and daylight layout tree use will use encircle layer. You can specify this parameter to
 #' `rect` (rectangular layer) or `encircle` (encircle layer), 'gradient' (gradient color), 
 #' 'roundrect' (round rectangular layer).
+#' @param to.bottom logical, whether set the high light layer to the bottom in all layers of 'ggtree'
+#' object, default is FALSE.
 #' @param ... additional parameters, see also the below and Aesthetics section.
 #'     \itemize{
 #'        \item \code{align} control the align direction of the edge of high light rectangular.
@@ -82,12 +84,14 @@ geom_hilight <- function(data=NULL,
                          mapping=NULL,
                          node=NULL,
                          type="auto",
+                         to.bottom=FALSE,
                           ...){
     params <- list(...)
     structure(list(data    = data,
                    mapping = mapping,
                    node    = node,
                    type    = type,
+                   to.bottom = to.bottom,
                    params  = params),
               class = 'hilight')
 }

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -532,7 +532,12 @@ ggplot_add.hilight <- function(object, plot, object_name){
                      roundrect = choose_hilight_layer(object = object, type = "roundrect")	 
                   )
     }
-    ggplot_add(ly, plot, object_name) 
+    plot <- ggplot_add(ly, plot, object_name)
+    if (object$to.bottom){
+        idx <- length(plot$layers)
+        plot$layers <- c(plot$layers[idx], plot$layers[-idx])
+    }
+    plot    
 }
 
 

--- a/man/geom-hilight.Rd
+++ b/man/geom-hilight.Rd
@@ -5,9 +5,23 @@
 \alias{geom_highlight}
 \title{geom_hilight}
 \usage{
-geom_hilight(data = NULL, mapping = NULL, node = NULL, type = "auto", ...)
+geom_hilight(
+  data = NULL,
+  mapping = NULL,
+  node = NULL,
+  type = "auto",
+  to.bottom = FALSE,
+  ...
+)
 
-geom_highlight(data = NULL, mapping = NULL, node = NULL, type = "auto", ...)
+geom_highlight(
+  data = NULL,
+  mapping = NULL,
+  node = NULL,
+  type = "auto",
+  to.bottom = FALSE,
+  ...
+)
 }
 \arguments{
 \item{data}{data.frame, The data to be displayed in this layer, defaults to NULL.}
@@ -21,6 +35,9 @@ slanted, fan, inward_circular, radial, equal_angle, ape layout tree will use rec
 unrooted and daylight layout tree use will use encircle layer. You can specify this parameter to
 \code{rect} (rectangular layer) or \code{encircle} (encircle layer), 'gradient' (gradient color),
 'roundrect' (round rectangular layer).}
+
+\item{to.bottom}{logical, whether set the high light layer to the bottom in all layers of 'ggtree'
+object, default is FALSE.}
 
 \item{...}{additional parameters, see also the below and Aesthetics section.
 \itemize{


### PR DESCRIPTION
+ introducing `to.bottom` argument to put the `geom_hilight` layer to the bottom of all layers

```
library(ggtree)
set.seed(102)
tree <- rtree(60)
dat <- data.frame(id=c(62, 88), type=c("A", "B"))
p <- ggtree(tree) + geom_hilight(data=dat, mapping=aes(node = id, fill=type), to.bottom=TRUE, alpha=1)
p
```
![xx](https://user-images.githubusercontent.com/17870644/164648527-424299a8-fa96-4835-b727-3032eabde3d4.PNG)
   
 