### PR TITLE
slanted layout when branch.length is none

### DIFF
--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -32,14 +32,20 @@ fortify.phylo <- function(model, data,
     if (layout %in% c("equal_angle", "daylight", "ape")) {
         res <- layout.unrooted(model, layout.method = layout, branch.length = branch.length, ...)
     } else {
+        ypos <- getYcoord(x)
+        N <- Nnode(x, internal.only=FALSE)
         if (is.null(x$edge.length) || branch.length == "none") {
-            xpos <- getXcoord_no_length(x)
+            if (layout == 'slanted'){
+                sbp <- .convert_tips2ancestors_sbp(x, include.root = TRUE)
+                xpos <- getXcoord_no_length_slanted(sbp)
+                ypos <- getYcoord_no_length_slanted(sbp)  
+            }else{
+                xpos <- getXcoord_no_length(x)
+            }
         } else {
             xpos <- getXcoord(x)
         }
 
-        ypos <- getYcoord(x)
-        N <- Nnode(x, internal.only=FALSE)
         xypos <- tibble::tibble(node=1:N, x=xpos + root.position, y=ypos)
 
         df <- as_tibble(model) %>%


### PR DESCRIPTION
+ adjust the `slanted` layout when `branch.length` is `none`.

   + related [issues](#496 ) and related [request](https://github.com/YuLab-SMU/ggtree/pull/422).

```
library(ggtree)
set.seed(123)
tr <- rtree(88)
tr %>% ggtree(layout='slanted', branch.length='none') + geom_tiplab(size=2.6)
```
![xx2](https://user-images.githubusercontent.com/17870644/165898042-228b0e7b-bff1-4115-9872-32c5717d6678.PNG)
