### PR TITLE
clone the plot environment before assigning layout

### DIFF
--- a/R/layout.R
+++ b/R/layout.R
@@ -15,6 +15,7 @@
 rotate_tree <- function(treeview, angle) {
     treeview <- treeview + coord_polar(theta='y', start=(angle-90)/180*pi, -1)
     treeview$data$angle <- treeview$data$angle + angle
+    treeview$plot_env <- build_new_plot_env(treeview$plot_env)
     assign("layout", "circular", envir = treeview$plot_env)
     return(treeview)
 }
@@ -46,6 +47,7 @@ open_tree <- function(treeview, angle) {
     angle <- 360/(2+NN) * (1:N+1)
     angle <- angle[idx]
     p$data$angle <- angle
+    p$plot_env <- build_new_plot_env(p$plot_env)
     assign("layout", "fan", envir = p$plot_env)
     return(p)
 }

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -115,8 +115,10 @@ ggplot_add.layout_ggtree <- function(object, plot, object_name) {
     } else { ## rectangular
         obj <- coord_cartesian(clip = 'off')
     }
+    plot <- ggplot_add(obj, plot, object_name)
+    plot$plot_env <- build_new_plot_env(plot$plot_env)
     assign("layout", object$layout, envir = plot$plot_env)
-    ggplot_add(obj, plot, object_name)
+    return(plot)
 }
 
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -17,6 +17,18 @@ get_layout <- function(tree_view = NULL) {
     return(layout)
 }
 
+build_new_plot_env <- function(env){
+    newenv <- list2env(
+                x = as.list(
+                  env, 
+                  all.names = TRUE
+                ), 
+                parent = parent.env(env)
+              )
+    attributes(newenv) <- attributes(env)
+    return(newenv)
+}
+
 reverse.treeview <- function(tv) {
     tv$data <- reverse.treeview.data(tv$data)
     return(tv)


### PR DESCRIPTION
+ clone the plot environment before assigning the `layout`

## original 

```
> library(ggtree)
ggtree v3.4.1 For help: https://yulab-smu.top/treedata-book/

If you use the ggtree package suite in published research, please cite
the appropriate paper(s):

Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam.
ggtree: an R package for visualization and annotation of phylogenetic
trees with their covariates and other associated data. Methods in
Ecology and Evolution. 2017, 8(1):28-36. doi:10.1111/2041-210X.12628

S Xu, Z Dai, P Guo, X Fu, S Liu, L Zhou, W Tang, T Feng, M Chen, L
Zhan, T Wu, E Hu, Y Jiang, X Bo, G Yu. ggtreeExtra: Compact
visualization of richly annotated phylogenetic data. Molecular Biology
and Evolution. 2021, 38(9):4039-4042. doi: 10.1093/molbev/msab166

Guangchuang Yu. Using ggtree to visualize data on tree-like structures.
Current Protocols in Bioinformatics. 2020, 69:e96. doi:10.1002/cpbi.96

> set.seed(123)
> tr <- rtree(66)
> p <- ggtree(tr)
> f <- p + layout_circular()
Scale for 'y' is already present. Adding another scale for 'y', which will
replace the existing scale.
> p$plot_env$layout
[1] "circular"
> f$plot_env$layout
[1] "circular"
> plot_list(p + geom_tiplab(), f + geom_tiplab())
```
![xx](https://user-images.githubusercontent.com/17870644/179512067-b9ad3f24-a80f-434f-9a91-03745efa581c.PNG)

The `p` should be `rectangular`

## This request

```
> library(ggtree)
ggtree v3.5.1.901 For help:
https://yulab-smu.top/treedata-book/

If you use the ggtree package suite in published research, please cite
the appropriate paper(s):

Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam.
ggtree: an R package for visualization and annotation of phylogenetic
trees with their covariates and other associated data. Methods in
Ecology and Evolution. 2017, 8(1):28-36. doi:10.1111/2041-210X.12628

Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods
for mapping and visualizing associated data on phylogeny using ggtree.
Molecular Biology and Evolution. 2018, 35(12):3041-3043.
doi:10.1093/molbev/msy194

LG Wang, TTY Lam, S Xu, Z Dai, L Zhou, T Feng, P Guo, CW Dunn, BR
Jones, T Bradley, H Zhu, Y Guan, Y Jiang, G Yu. treeio: an R package
for phylogenetic tree input and output with richly annotated and
associated data. Molecular Biology and Evolution. 2020, 37(2):599-603.
doi: 10.1093/molbev/msz240
> set.seed(123)
> tr <- rtree(66)
> p <- ggtree(tr)
> f <- p + layout_circular()
Scale for 'y' is already present. Adding another scale for 'y', which will
replace the existing scale.
> get('layout', p$plot_env)
[1] "rectangular"
> get('layout', f$plot_env)
[1] "circular"
> plot_list(p+geom_tiplab(), f+geom_tiplab())
```
![xx1](https://user-images.githubusercontent.com/17870644/179512040-a08370b4-b86f-4551-b7b3-afbe00621d43.PNG)

