### PR TITLE
adjust the height of hclust-like class with dendrogram layout

### DIFF
--- a/R/axis.R
+++ b/R/axis.R
@@ -117,6 +117,10 @@ revts <- function(treeview) {
     mx <- max(x, na.rm=TRUE)
     treeview$data$x <- x - mx
     treeview$data$branch <- treeview$data$branch - mx
+	tip.edge.len <- attr(treeview$data, 'tip.edge.len')
+    if (!is.null(tip.edge.len)){
+        treeview$data[treeview$data$isTip,"x", drop=TRUE] <- tip.edge.len
+    }
     treeview
 }
 

--- a/R/axis.R
+++ b/R/axis.R
@@ -113,14 +113,14 @@ scale_x_range <- function() {
 ##' p2 + scale_x_continuous(labels=abs)
 ##' @author Guangchuang Yu
 revts <- function(treeview) {
+    if (attr(treeview$data, 'revts.done')){
+         return(treeview)
+    }
     x <- treeview$data$x
     mx <- max(x, na.rm=TRUE)
     treeview$data$x <- x - mx
     treeview$data$branch <- treeview$data$branch - mx
 	tip.edge.len <- attr(treeview$data, 'tip.edge.len')
-    if (!is.null(tip.edge.len)){
-        treeview$data[treeview$data$isTip,"x", drop=TRUE] <- tip.edge.len
-    }
     treeview
 }
 

--- a/R/ggtree.R
+++ b/R/ggtree.R
@@ -17,6 +17,9 @@
 ##' @param root.position position of the root node (default = 0)
 ##' @param xlim x limits, only works for 'inward_circular' layout
 ##' @param layout.params list, the parameters of layout, when layout is a function.
+##' @param hang numeric The fraction of the tree plot height by which labels should hang 
+##' below the rest of the plot. A negative value will cause the labels to hang down from 0. This
+##' parameter only work with the 'dendrogram' layout for 'hclust' like class, default is 0.1.
 ##' @return tree
 ##' @importFrom ggplot2 ggplot
 ##' @importFrom ggplot2 xlab
@@ -59,6 +62,7 @@ ggtree <- function(tr,
                    root.position  = 0,
                    xlim = NULL,
                    layout.params = list(),
+                   hang = .1,
                    ...) {
 
     # Check if layout string is valid.
@@ -102,6 +106,7 @@ ggtree <- function(tr,
                 right         = right,
                 branch.length = branch.length,
                 root.position = root.position,
+                hang          = hang,
                 ...)
 
     if (!is.null(dd)){

--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -133,19 +133,23 @@ fortify.phylo4 <- function(model, data,
                            ladderize = TRUE,
                            right     = FALSE,
                            mrsd      = NULL,
+                           hang      = .1,
                            ...) {
     if (inherits(model, c("dendrogram", "agnes", "diana", "twins"))) {
         model <- stats::as.hclust(model)
     }
 
-    if (inherits(model, "hclust")) {
-        phylo <- as.phylo.hclust2(model)
+    if (inherits(model, "hclust") && layout == 'dendrogram') {
+        phylo <- as.phylo.hclust2(model, hang = hang)
     } else {
         phylo <- as.phylo(model)
     }
 
     df <- fortify.phylo(phylo, data,
                         layout, ladderize, right, mrsd=mrsd, ...)
+    if (!is.null(attr(phylo, 'tip.edge.len'))){
+        attr(df, 'tip.edge.len') <- attr(phylo, 'tip.edge.len')
+    }
     scaleY(phylo, df, yscale, layout, ...)
 }
 

--- a/R/method-fortify.R
+++ b/R/method-fortify.R
@@ -139,7 +139,7 @@ fortify.phylo4 <- function(model, data,
         model <- stats::as.hclust(model)
     }
 
-    if (inherits(model, "hclust") && layout == 'dendrogram') {
+    if (inherits(model, "hclust")) {
         phylo <- as.phylo.hclust2(model, hang = hang)
     } else {
         phylo <- as.phylo(model)
@@ -147,9 +147,14 @@ fortify.phylo4 <- function(model, data,
 
     df <- fortify.phylo(phylo, data,
                         layout, ladderize, right, mrsd=mrsd, ...)
-    if (!is.null(attr(phylo, 'tip.edge.len'))){
-        attr(df, 'tip.edge.len') <- attr(phylo, 'tip.edge.len')
+    mx <- max(df$x, na.rm=TRUE)
+    df$x <- df$x - mx
+    df$branch <- df$branch - mx
+    tip.edge.len <- attr(phylo, 'tip.edge.len')
+    if (!is.null(tip.edge.len)){
+        df[df$isTip, "x", drop=TRUE] <- tip.edge.len
     }
+    attr(df, 'revts.done') = TRUE
     scaleY(phylo, df, yscale, layout, ...)
 }
 

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -202,8 +202,16 @@ ggplot_add.facet_plot <- function(object, plot, object_name) {
 ##' @export
 ggplot_add.tiplab <- function(object, plot, object_name) {
     layout <- get_layout(plot)
-    if (layout == 'dendrogram' && object$hjust == 0 ){
-        object$hjust <- .5
+    if (layout == 'dendrogram'){
+        if( object$hjust == 0 ){
+            object$hjust = 1
+        }
+        if (!'vjust' %in% names(object)){
+            object$vjust = .5
+        }
+        if (!'angle' %in% names(object)){
+            object$angle = 90
+        }
     }
     if (object$as_ylab) {
         if (layout != "rectangular" && layout != "dendrogram") {

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -100,7 +100,7 @@ ggplot_add.layout_ggtree <- function(object, plot, object_name) {
 
     if (object$layout == 'dendrogram') {
         plot <- revts(plot)
-        obj <- list(scale_x_reverse(labels = abs),
+        obj <- list(scale_x_reverse(labels = function(x){-x}),
                     coord_flip(clip = 'off')
                     )
     } else if (object$layout == 'circular' || object$layout == "inward_circular") {

--- a/R/tree-utilities.R
+++ b/R/tree-utilities.R
@@ -1355,14 +1355,21 @@ as.phylo.hclust2 <- function(x, hang=0.1, ...) {
     }
   }
 
-  len <- numeric(max(tr$edge))
-  len[nodes] <- h$height
-  pn <- ev[nodes]
-  pn[pn == 0] <- treeio::rootnode(tr)
-  len[nodes] <- len[pn] - len[nodes]
-  len[1:Ntip(tr)] <- hang #max(h$height)/10
+  #len <- numeric(max(tr$edge))
+  #len[nodes] <- h$height
+  #pn <- ev[nodes]
+  #pn[pn == 0] <- treeio::rootnode(tr)
+  #len[nodes] <- len[pn] - len[nodes]
+  #len[1:Ntip(tr)] <- hang #max(h$height)/10
 
-  tr$edge.length <- len[tr$edge[,2]]
+  #tr$edge.length <- len[tr$edge[,2]]
+
+  tip2parent <- tr$edge[match(seq_len(Ntip(tr)), tr$edge[,2]), 1]
+  if (hang > 0){
+    tip.edge.len <- hang * max(h$height) - h$height[match(tip2parent, nodes)]
+    attr(tr,'tip.edge.len') <- tip.edge.len
+  }
+  tr$edge.length <- tr$edge.length * 2
   return(tr)
 }
 

--- a/man/ggtree.Rd
+++ b/man/ggtree.Rd
@@ -22,6 +22,7 @@ ggtree(
   root.position = 0,
   xlim = NULL,
   layout.params = list(),
+  hang = 0.1,
   ...
 )
 }
@@ -56,6 +57,10 @@ right-hand side? See \code{\link[ape:ladderize]{ape::ladderize()}} for more info
 \item{xlim}{x limits, only works for 'inward_circular' layout}
 
 \item{layout.params}{list, the parameters of layout, when layout is a function.}
+
+\item{hang}{numeric The fraction of the tree plot height by which labels should hang
+below the rest of the plot. A negative value will cause the labels to hang down from 0. This
+parameter only work with the 'dendrogram' layout for 'hclust' like class, default is 0.1.}
 
 \item{...}{additional parameter
 


### PR DESCRIPTION
+ adjust the tip nodes height of `hclust`-like class with dendrogram layout

```
library(ggtree)
hc <- hclust(dist(USArrests), "ave")
p <- ggtree(hc, layout='den') + 
geom_tiplab(angle=90, hjust=1, vjust=.5,size=3) + 
theme_dendrogram(plot.margin=margin(6, 6, 80, 6))
plot_list(p, ~plot(hc))
```
![xx](https://user-images.githubusercontent.com/17870644/179923407-1bfaf5bf-ef75-4058-91e0-c439bed8a94e.PNG)
