### PR TITLE
fix bug for geom_hilight when layout is daylight or graph layout function

### DIFF
--- a/R/axis.R
+++ b/R/axis.R
@@ -113,7 +113,7 @@ scale_x_range <- function() {
 ##' p2 + scale_x_continuous(labels=abs)
 ##' @author Guangchuang Yu
 revts <- function(treeview) {
-    if (attr(treeview$data, 'revts.done')){
+    if (!is.null(attr(treeview$data, 'revts.done'))){
          return(treeview)
     }
     x <- treeview$data$x

--- a/R/method-ggplot-add.R
+++ b/R/method-ggplot-add.R
@@ -528,6 +528,9 @@ ggplot_add.hilight <- function(object, plot, object_name){
         if (flag_tbl_tree){
             object$data <-  object$data[,!colnames(object$data) %in% setdiff(flag_names, as_name(object$mapping$node)),drop=FALSE]
         }
+        object$data <- object$data[, !colnames(object$data) %in% setdiff(intersect(colnames(object$data), 
+                                                                     colnames(data)), 
+                                                                     as_name(object$mapping$node)), drop=FALSE]
         object$data <- merge(data, object$data, by.x="clade_root_node", by.y=as_name(object$mapping$node))
         object$data[[as_name(object$mapping$node)]] <- as.vector(object$data$clade_root_node)
         object$mapping <- object$mapping[!names(object$mapping) %in% c("node")]


### PR DESCRIPTION
# example

```
> library(ggtree)
ggtree v3.5.1.902 For help:
https://yulab-smu.top/treedata-book/

If you use the ggtree package suite in published research, please cite
the appropriate paper(s):

Guangchuang Yu, David Smith, Huachen Zhu, Yi Guan, Tommy Tsan-Yuk Lam.
ggtree: an R package for visualization and annotation of phylogenetic
trees with their covariates and other associated data. Methods in
Ecology and Evolution. 2017, 8(1):28-36. doi:10.1111/2041-210X.12628

S Xu, Z Dai, P Guo, X Fu, S Liu, L Zhou, W Tang, T Feng, M Chen, L
Zhan, T Wu, E Hu, Y Jiang, X Bo, G Yu. ggtreeExtra: Compact
visualization of richly annotated phylogenetic data. Molecular Biology
and Evolution. 2021, 38(9):4039-4042. doi: 10.1093/molbev/msab166

Guangchuang Yu, Tommy Tsan-Yuk Lam, Huachen Zhu, Yi Guan. Two methods
for mapping and visualizing associated data on phylogeny using ggtree.
Molecular Biology and Evolution. 2018, 35(12):3041-3043.
doi:10.1093/molbev/msy194
> tr <- rtree(10)
> ggtree(tr, layout=igraph::layout_with_kk) + geom_hilight(data=td_filter(node %in% c(14, 16)), mapping=aes(node=node, fill=as.factor(node)))
The tree object will be displayed with graph layout since layout argument was
specified the graph layout function.
>
```
![xx](https://user-images.githubusercontent.com/17870644/182614369-411bbb98-3fca-4b17-a33d-2bb828f48161.PNG)
